### PR TITLE
Increase the default miner max storage size

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -10,11 +10,17 @@ from functools import lru_cache, update_wrapper
 
 _KB = 1024
 _MB = 1024 * _KB
+_GB = 1024 * _MB
 
 
 def mb_to_bytes(mb: int) -> int:
     """Returns the total number of bytes."""
     return mb * _MB
+
+
+def gb_to_bytes(gb: int) -> int:
+    """Returns the total number of bytes."""
+    return gb * _GB
 
 
 def seconds_to_hours(seconds: int) -> int:

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -150,10 +150,12 @@ def add_args(neuron_type: NeuronType, parser):
         )
 
         parser.add_argument(
-            "--neuron.max_database_size_bytes_hint",
+            "--neuron.max_database_size_gb_hint",
             type=int,
-            help="Hint for the size of the database to target. Expect additional some additional overhead.",
-            default=utils.mb_to_bytes(10000),
+            help="Hint for the size of the database to target in GBs. Expect additional some additional overhead.",
+            # We intentionally choose a large default to avoid Miner's accidentally deleting data when they
+            # run with the default value.
+            default=250,
         )
 
         root_dir = Path(os.path.dirname(__file__)).parent

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -64,7 +64,7 @@ class Miner(BaseNeuron):
         # Instantiate storage.
         self.storage = SqliteMinerStorage(
             self.config.neuron.database_name,
-            self.config.neuron.max_database_size_bytes_hint,
+            self.config.neuron.max_database_size_gb_hint,
         )
 
         # Configure the ScraperCoordinator

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -72,13 +72,15 @@ class SqliteMinerStorage(MinerStorage):
     def __init__(
         self,
         database="SqliteMinerStorage.sqlite",
-        max_database_size_bytes_hint=utils.mb_to_bytes(10000),
+        max_database_size_gb_hint=250,
     ):
         sqlite3.register_converter("timestamp", tz_aware_timestamp_adapter)
         self.database = database
 
         # TODO Account for non-content columns when restricting total database size.
-        self.database_max_content_size_bytes = max_database_size_bytes_hint
+        self.database_max_content_size_bytes = utils.gb_to_bytes(
+            max_database_size_gb_hint
+        )
 
         with contextlib.closing(self._create_connection()) as connection:
             cursor = connection.cursor()

--- a/tests/neurons/test_miner_config.py
+++ b/tests/neurons/test_miner_config.py
@@ -23,7 +23,7 @@ class TestMinerConfig(unittest.TestCase):
 
             self.assertEqual(config.neuron.database_name, "mydb")
             # Check the default values are still there.
-            self.assertEqual(config.neuron.max_database_size_bytes_hint, 10485760000)
+            self.assertEqual(config.neuron.max_database_size_gb_hint, 250)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change also updates the flag to use GB instead of bytes to make it much easier to set the flag via command line