### PR TITLE
Compress the MinerIndex

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -8,3 +8,6 @@ DATA_ENTITY_BUCKET_SIZE_LIMIT_BYTES = utils.mb_to_bytes(128)
 DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX = 3000000
 # How old a data entity bucket can be before the validators do not assign any value for them.
 DATA_ENTITY_BUCKET_AGE_LIMIT_DAYS = 30
+
+# The current protocol version.
+PROTOCOL_VERSION = 1

--- a/common/constants.py
+++ b/common/constants.py
@@ -9,5 +9,8 @@ DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX = 3000000
 # How old a data entity bucket can be before the validators do not assign any value for them.
 DATA_ENTITY_BUCKET_AGE_LIMIT_DAYS = 30
 
+# The maximum length of a data label.
+MAX_DATA_LABEL_LENGTH = 32
+
 # The current protocol version.
 PROTOCOL_VERSION = 1

--- a/common/data.py
+++ b/common/data.py
@@ -108,6 +108,10 @@ class DataLabel:
     def __getattribute__(self, prop):
         if prop == "value":
             v = super().__getattribute__(prop)
+            if v and len(v) > constants.MAX_DATA_LABEL_LENGTH:
+                raise ValueError(
+                    f"DataLabel cannot be longer than {constants.MAX_DATA_LABEL_LENGTH} characters."
+                )
             return v.lower() if v else None
         return super().__getattribute__(prop)
 

--- a/common/old_data.py
+++ b/common/old_data.py
@@ -1,0 +1,190 @@
+"""This file contains the previous versions of our data models.
+
+This is kept around to verify backwards compatibility of the wire protocol."""
+
+import dataclasses
+from common import constants
+from . import utils
+import datetime as dt
+from enum import Enum, IntEnum, auto
+from typing import List, Type, Optional
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, validator
+
+
+class StrictBaseModel(BaseModel):
+    """A BaseModel that enforces stricter validation constraints"""
+
+    class Config:
+        extra = "forbid"
+
+        # JSON serialization doesn't seem to work correctly without
+        # enabling `use_enum_values`. It's possible this isn't an
+        # issue with newer version of pydantic, which we can't use.
+        use_enum_values = True
+
+
+@dataclasses.dataclass(frozen=True)
+class DateRange:
+    """Represents a specific time range from start time inclusive to end time exclusive."""
+
+    # The start time inclusive of the time range.
+    start: dt.datetime
+
+    # The end time exclusive of the time range.
+    end: dt.datetime
+
+    def contains(self, datetime: dt.datetime) -> bool:
+        """Returns True if the provided datetime is within this DateRange."""
+        return self.start <= datetime < self.end
+
+
+class TimeBucket(StrictBaseModel):
+    """Represents a specific time bucket in the linear flow of time."""
+
+    # Makes the object "Immutable" once created.
+    model_config = ConfigDict(frozen=True)
+
+    id: PositiveInt = Field(
+        description="Monotonically increasing value idenitifying the given time bucket"
+    )
+
+    @classmethod
+    def from_datetime(cls, datetime: dt.datetime) -> Type["TimeBucket"]:
+        """Creates a TimeBucket from the provided datetime.
+
+        Args:
+            datetime (datetime.datetime): A datetime object, assumed to be in UTC.
+        """
+        datetime.astimezone(dt.timezone.utc)
+        return TimeBucket(
+            id=utils.seconds_to_hours(
+                datetime.astimezone(tz=dt.timezone.utc).timestamp()
+            )
+        )
+
+    @classmethod
+    def to_date_range(cls, bucket: "TimeBucket") -> DateRange:
+        """Returns the date range for this time bucket."""
+        return DateRange(
+            start=utils.datetime_from_hours_since_epoch(bucket.id),
+            end=utils.datetime_from_hours_since_epoch(bucket.id + 1),
+        )
+
+
+class DataSource(IntEnum):
+    """The source of data. This will be expanded over time as we increase the types of data we collect."""
+
+    REDDIT = 1
+    X = 2
+
+
+class DataLabel(StrictBaseModel):
+    """An optional label to classify a data entity. Each data source will have its own definition and interpretation of labels.
+
+    For example, in Reddit a label is the subreddit. For a stock price, it'll be the ticker symbol.
+    """
+
+    class Config:
+        frozen = True
+
+    value: str = Field(
+        max_length=32,
+        description="The label. E.g. a subreddit for Reddit data.",
+    )
+
+    @validator("value")
+    @classmethod
+    def lower_case_value(cls, value: str) -> str:
+        """Converts the value to lower case to consistent casing throughout the system."""
+        return value.lower()
+
+
+class DataEntity(StrictBaseModel):
+    """A logical unit of data that has been scraped. E.g. a Reddit post"""
+
+    # Makes the object "Immutable" once created.
+    model_config = ConfigDict(frozen=True)
+
+    # Path from which the entity was generated.
+    uri: str
+    # The datetime of the data entity, usually its creation time.
+    # Should be in UTC.
+    datetime: dt.datetime
+    source: DataSource
+    label: Optional[DataLabel] = Field(
+        default=None,
+    )
+    content: bytes
+    content_size_bytes: int = Field(ge=0)
+
+    @classmethod
+    def are_non_content_fields_equal(
+        cls, this: "DataEntity", other: "DataEntity"
+    ) -> bool:
+        """Returns whether this entity matches the non-content fields of another entity."""
+        return (
+            this.uri == other.uri
+            and this.datetime == other.datetime
+            and this.source == other.source
+            and this.label == other.label
+        )
+
+
+class DataEntityBucketId(StrictBaseModel):
+    """Uniquely identifies a bucket to group DataEntities by time bucket, source, and label."""
+
+    time_bucket: TimeBucket
+    source: DataSource = Field()
+    label: Optional[DataLabel] = Field(
+        default=None,
+    )
+
+
+class DataEntityBucket(StrictBaseModel):
+    """Summarizes a group of data entities stored by a miner.
+
+    Each bucket is uniquely identified by the time bucket, source, and label and it must be complete. i.e. a mine
+    should never report multiple chunks for the same time bucket, source, and label.
+
+    A single bucket is limited to 128MBs to ensure requests sent over the network aren't too large.
+    """
+
+    id: DataEntityBucketId = Field(
+        description="Identifies the qualities by which this bucket is grouped."
+    )
+    size_bytes: int = Field(ge=0, le=constants.DATA_ENTITY_BUCKET_SIZE_LIMIT_BYTES)
+
+
+class ScorableDataEntityBucket(StrictBaseModel):
+    """Composes both a DataEntityBucket and additional information required for scoring."""
+
+    data_entity_bucket: DataEntityBucket = Field(
+        description="The DataEntityBucket that has additional information attached."
+    )
+    # Scorable bytes are the bytes that can be credited to this miner for scoring.
+    # This is always less than or equal to the total size of the chunk.
+    # This scorable bytes are computed as:
+    # 1 byte for every byte in size_bytes that no other miner has in their index.
+    # 1 byte / # of miners that have this chunk in their index for every byte in size_bytes that at least one other miner has in their index.
+    scorable_bytes: int = Field(ge=0, le=constants.DATA_ENTITY_BUCKET_SIZE_LIMIT_BYTES)
+
+
+class MinerIndex(StrictBaseModel):
+    """The Miner index."""
+
+    hotkey: str = Field(min_length=1, description="ss58_address of the miner's hotkey.")
+    data_entity_buckets: List[DataEntityBucket] = Field(
+        description="Buckets the miner is serving.",
+        max_items=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX,
+    )
+
+
+class ScorableMinerIndex(StrictBaseModel):
+    """The Miner index, with additional information required for scoring."""
+
+    hotkey: str = Field(min_length=1, description="ss58_address of the miner's hotkey.")
+    scorable_data_entity_buckets: List[ScorableDataEntityBucket] = Field(
+        description="DataEntityBuckets the miner is serving, scored on uniqueness.",
+        max_items=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX,
+    )
+    last_updated: dt.datetime = Field(description="Time last updated in UTC.")

--- a/common/old_protocol.py
+++ b/common/old_protocol.py
@@ -1,0 +1,59 @@
+"""This file contains the previous versions of our data models.
+
+This is kept around to verify backwards compatibility of the wire protocol."""
+
+import bittensor as bt
+import pydantic
+from common import constants
+from common.old_data import DataEntityBucket, DataEntity, DataEntityBucketId
+from typing import List, Optional
+
+
+class GetMinerIndex(bt.Synapse):
+    """
+    Protocol by which Validators can retrieve the Index from a Miner.
+
+    Attributes:
+    - data_entity_buckets: A list of DataEntityBucket objects that the Miner can serve.
+    """
+
+    # Required request output, filled by receiving axon.
+    data_entity_buckets: List[DataEntityBucket] = pydantic.Field(
+        title="data_entity_buckets",
+        description="All of the data entity buckets that a Miner can serve.",
+        frozen=False,
+        repr=False,
+        max_items=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX,
+        default_factory=list,
+    )
+
+
+class GetDataEntityBucket(bt.Synapse):
+    """
+    Protocol by which Validators can retrieve the DataEntities of a Bucket from a Miner.
+
+    Attributes:
+    - bucket_id: The id of the bucket that the requester is asking for.
+    - data_entities: A list of DataEntity objects that make up the requested DataEntityBucket.
+    """
+
+    # Required request input, filled by sending dendrite caller.
+    data_entity_bucket_id: Optional[DataEntityBucketId] = pydantic.Field(
+        title="data_entity_bucket_id",
+        description="The identifier for the requested DataEntityBucket.",
+        frozen=True,
+        repr=False,
+        default=None,
+    )
+
+    # Required request output, filled by recieving axon.
+    data_entities: List[DataEntity] = pydantic.Field(
+        title="data_entities",
+        description="All of the data that makes up the requested DataEntityBucket.",
+        frozen=False,
+        repr=False,
+        default_factory=list,
+    )
+
+
+# TODO Protocol for Users to Query Data which will accept query parameters such as a startDatetime, endDatetime.

--- a/common/pydantic_dict_encoder.py
+++ b/common/pydantic_dict_encoder.py
@@ -1,0 +1,108 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    ForwardRef,
+    Optional,
+    Type,
+    Union,
+    cast,
+)
+
+from pydantic import BaseConfig, BaseModel
+
+if TYPE_CHECKING:
+    from pydantic.typing import (
+        AbstractSetIntStr,
+        AnyCallable,
+        MappingIntStrAny,
+    )
+
+__all__ = ("PydanticDictEncodersMixin",)
+
+
+class PydanticDictEncodersMixin:
+    """
+    Pydantic mixin for support dict encode like json (json_encoders/json).
+    ```
+    class AnyModel(PydanticDictEncodersMixin, BaseModel):
+        any_field: str | None = None
+
+        class Config:
+            dict_encoders = {}
+            jsonify_dict_encode = False
+    ```
+
+    WARNING! Please, remember about python MRO: BaseModel MUST BE after mixin.
+
+    Config specification:
+        - `dict_encoders` - map of dict encoders. Working as standart pydantic `json_encoders`
+        - `jsonify_dict_encode` - flag of convert values as though using .json() for each fields
+    """  # noqa: E501
+
+    class Config(BaseConfig):
+        # Dict encoders like json_encoders
+        dict_encoders: Dict[Union[Type[Any], str, ForwardRef], "AnyCallable"] = {}
+        # To dict encoding value like json value
+        jsonify_dict_encode: bool = False
+
+    if TYPE_CHECKING:
+        __config__: ClassVar[Type["Config"]] = Config
+        __json_encoder__: ClassVar[Callable[[Any], Any]]
+
+    @classmethod
+    def _get_value_like_json(
+        cls,
+        v: Any,
+    ) -> Any:
+        v = cls.__config__.json_dumps(v, default=cls.__json_encoder__)
+        if v.startswith('"'):
+            return v[1:-1]
+        return v
+
+    @classmethod
+    def _get_value_custom_encoder(cls, v: Any) -> Optional[Callable[[Any], Any]]:
+        for _type, encoder in cls.__config__.dict_encoders.items():
+            if isinstance(v, _type):  # type: ignore
+                return encoder
+        return None
+
+    @classmethod
+    def _get_value(
+        cls,
+        v: Any,
+        to_dict: bool,
+        by_alias: bool,
+        include: Optional[Union["AbstractSetIntStr", "MappingIntStrAny"]],
+        exclude: Optional[Union["AbstractSetIntStr", "MappingIntStrAny"]],
+        exclude_unset: bool,
+        exclude_defaults: bool,
+        exclude_none: bool,
+    ) -> Any:
+        encoder = None
+        dict_encoders = getattr(cls.__config__, "dict_encoders", {})
+        jsonify_dict_encode = getattr(cls.__config__, "jsonify_dict_encode", False)
+        if dict_encoders:
+            encoder = cast(Callable[[Any], Any], cls._get_value_custom_encoder(v))
+        if (
+            not encoder
+            and jsonify_dict_encode
+            and not isinstance(v, (list, dict, BaseModel))
+        ):
+            encoder = cls._get_value_like_json
+        if jsonify_dict_encode and isinstance(v, (PydanticDictEncodersMixin)):
+            v.__config__.jsonify_dict_encode = True
+        if encoder:
+            v = encoder(v)
+        return super()._get_value(  # type: ignore
+            v,
+            to_dict,
+            by_alias,
+            include,
+            exclude,
+            exclude_unset,
+            exclude_defaults,
+            exclude_none,
+        )

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -22,7 +22,7 @@ import time
 import traceback
 import typing
 import bittensor as bt
-from common import utils
+from common import constants, utils
 from common.protocol import GetDataEntityBucket, GetMinerIndex
 from neurons.config import NeuronType
 from scraping.config.config_reader import ConfigReader
@@ -243,6 +243,8 @@ class Miner(BaseNeuron):
 
         # List all the data entity buckets that this miner currently has.
         synapse.data_entity_buckets = self.storage.list_data_entity_buckets()
+
+        # TODO: Use the compressed index instead.
 
         bt.logging.debug(
             f"Returning miner index with size: {len(synapse.data_entity_buckets)}"

--- a/storage/validator/mysql_validator_storage.py
+++ b/storage/validator/mysql_validator_storage.py
@@ -186,7 +186,7 @@ class MysqlValidatorStorage(ValidatorStorage):
                 [
                     miner_id,
                     data_entity_bucket.id.time_bucket.id,
-                    data_entity_bucket.id.source,
+                    int(data_entity_bucket.id.source),
                     label_id,
                     data_entity_bucket.size_bytes,
                 ]
@@ -271,22 +271,24 @@ class MysqlValidatorStorage(ValidatorStorage):
             total_content_size_bytes = row["totalContentSize"]
 
             # Score the bytes as the fraction of the total content bytes for that bucket across all valid miners.
+            data_label = None
+            if label != "NULL":
+                data_label = DataLabel(value=label)
+
             data_entity_bucket_id = DataEntityBucketId(
                 time_bucket=TimeBucket(id=row["timeBucketId"]),
                 source=row["source"],
+                label=data_label,
             )
 
-            if label != "NULL":
-                data_entity_bucket_id.label = DataLabel(value=label)
-
             data_entity_bucket = DataEntityBucket(
-                id=data_entity_bucket_id, size_bytes=content_size_bytes
+                id=data_entity_bucket_id, size_bytes=int(content_size_bytes)
             )
             scored_data_entity_bucket = ScorableDataEntityBucket(
                 data_entity_bucket=data_entity_bucket,
-                scorable_bytes=content_size_bytes
-                * content_size_bytes
-                / total_content_size_bytes,
+                scorable_bytes=float(
+                    content_size_bytes * content_size_bytes / total_content_size_bytes
+                ),
             )
 
             # Add the bucket to the list of scored buckets on the overall index.

--- a/tests/common/test_data.py
+++ b/tests/common/test_data.py
@@ -1,7 +1,21 @@
 import datetime as dt
+import time
+from pydantic import ValidationError
 
-from common.data import DataSource, TimeBucket
+from common import constants, utils
+
+from common.data import (
+    CompressedMinerIndex,
+    DataEntityBucket,
+    DataEntityBucketId,
+    DataLabel,
+    DataSource,
+    MinerIndex,
+    TimeBucket,
+)
 import unittest
+
+from common.protocol import GetMinerIndex
 
 
 class TestData(unittest.TestCase):
@@ -23,6 +37,136 @@ class TestData(unittest.TestCase):
         """Tests that the data source enum can be initialized"""
         source = 1
         self.assertEqual(DataSource.REDDIT, DataSource(source))
+
+    def test_index_compression(self):
+        """Tests that the index compression works"""
+
+        index = MinerIndex(
+            hotkey="hotkey",
+            data_entity_buckets=[
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        source=DataSource.REDDIT,
+                        label=DataLabel(value="r/bittensor_"),
+                        time_bucket=TimeBucket(id=5),
+                    ),
+                    size_bytes=100,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        source=DataSource.REDDIT,
+                        label=DataLabel(value="r/bittensor_"),
+                        time_bucket=TimeBucket(id=6),
+                    ),
+                    size_bytes=250,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        source=DataSource.REDDIT,
+                        time_bucket=TimeBucket(id=5),
+                    ),
+                    size_bytes=10,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        source=DataSource.X,
+                        # It's unrealistic, but share a label and time bucket with an entity from a different source.
+                        label=DataLabel(value="r/bittensor_"),
+                        time_bucket=TimeBucket(id=5),
+                    ),
+                    size_bytes=100,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        source=DataSource.X,
+                        time_bucket=TimeBucket(id=5),
+                    ),
+                    size_bytes=10,
+                ),
+            ],
+        )
+
+        compressed_index = MinerIndex.compress(index)
+        self.assertEqual(
+            index, CompressedMinerIndex.decompress(compressed_index, "hotkey")
+        )
+
+    def test_deserialize_from_old_model(self):
+        """Verifies the current data models can deserialize from the old pydantic model form, that used
+        to have an extra model_config arg."""
+        GetMinerIndex.parse_raw(
+            '{"name": "GetMinerIndex", "timeout": 12.0, "total_size": 0, "header_size": 0, "data_entity_buckets": [{"id": {"time_bucket": {"id": 5, "model_config": {"frozen": true}}, "source": 1, "label": {"value": "r/BitTensor"}}, "size_bytes": 100}]}'
+        )
+
+    def test_label_is_lower_cased(self):
+        """Tests that the label is lower cased when even if the raw json uses upper case."""
+        index = GetMinerIndex.parse_raw(
+            '{"name": "GetMinerIndex", "timeout": 12.0, "total_size": 0, "header_size": 0, "data_entity_buckets": [{"id": {"time_bucket": {"id": 5}, "source": 1, "label": {"value": "r/BitTensor"}}, "size_bytes": 100}]}'
+        )
+
+        self.assertEqual(index.data_entity_buckets[0].id.label.value, "r/bittensor")
+
+    def test_get_miner_index_performs_validation(self):
+        """Tests that basic validation is performed when deserializing a GetMinerIndex."""
+        with self.assertRaises(ValidationError):
+            # Parse with an invalid data source.
+            GetMinerIndex.parse_raw(
+                '{"name": "GetMinerIndex", "timeout": 12.0, "total_size": 0, "header_size": 0, "data_entity_buckets": [{"id": {"time_bucket": {"id": 5}, "source": 5, "label": {"value": "r/BitTensor"}}, "size_bytes": 100}]}'
+            )
+
+    def test_compression_supports_max_index(self):
+        """Tests that the compressed version of the maximal Miner index is under our response size limit."""
+
+        target_buckets = constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX
+
+        # Figure out how many time buckets and labels we need to fill the index.
+        buckets_per_source = target_buckets // len(DataSource)
+        num_time_buckets = constants.DATA_ENTITY_BUCKET_AGE_LIMIT_DAYS * 7 * 24
+        num_labels = buckets_per_source // num_time_buckets
+
+        # Double check the math
+        total_buckets = len(DataSource) * num_time_buckets * num_labels
+        self.assertAlmostEqual(
+            target_buckets,
+            total_buckets,
+            delta=target_buckets * 0.05,
+        )
+
+        entity_buckets = [None] * total_buckets
+        i = 0
+        start = time.time()
+        for source in list(DataSource):
+            for label_id in range(0, num_labels):
+                for time_bucket_id in range(1, num_time_buckets + 1):
+                    entity_buckets[i] = DataEntityBucket(
+                        id=DataEntityBucketId(
+                            source=source,
+                            label=DataLabel(value=f"label_{label_id}"),
+                            time_bucket=TimeBucket(id=time_bucket_id),
+                        ),
+                        size_bytes=100,
+                    )
+                    i += 1
+
+        print(f"Time to create index: {time.time() - start}")
+        maximal_index = MinerIndex(
+            hotkey="hotkey",
+            data_entity_buckets=entity_buckets,
+        )
+
+        start = time.time()
+        compressed_index = MinerIndex.compress(maximal_index)
+        print(f"Time to compress index: {time.time() - start}")
+
+        start = time.time()
+        message_new = GetMinerIndex(compressed_index=compressed_index)
+        print(f"Time to create synapse: {time.time() - start}")
+
+        start = time.time()
+        compressed_json = message_new.json()
+        print(f"Time to serialize synapse: {time.time() - start}")
+        print(f"Compressed index size: {len(compressed_json)}")
+        self.assertLess(len(compressed_json), utils.mb_to_bytes(mb=128))
 
 
 if __name__ == "__main__":

--- a/tests/common/test_protocol.py
+++ b/tests/common/test_protocol.py
@@ -1,33 +1,227 @@
+import json
+import time
+from typing import Type
 import unittest
 import datetime as dt
+import bittensor as bt
+from h11 import Data
 from common.data import (
+    CompressedEntityBucket,
+    CompressedMinerIndex,
     DataEntity,
+    DataEntityBucket,
     DataEntityBucketId,
     DataLabel,
     DataSource,
     TimeBucket,
 )
+from common import old_data, old_protocol
 
 from common.protocol import GetDataEntityBucket, GetMinerIndex
 
 
+def serialize_like_dendrite(synapse: bt.Synapse) -> str:
+    """Serializes a synapse like a Dendrite would."""
+    d = synapse.dict()
+    return json.dumps(d)
+
+
+def serialize_like_axon(synapse: bt.Synapse) -> str:
+    """Serializes a synapse like an Axon would."""
+    return synapse.json()
+
+
+def deserialize(json_str: str, cls: Type) -> bt.Synapse:
+    """Deserializes the same way a dendrite/axon does."""
+    d = json.loads(json_str)
+    return cls(**d)
+
+
 class TestGetMinerIndex(unittest.TestCase):
-    def test_synapse_serialization(self):
+    def test_get_miner_index_old_format_round_trip(self):
         """Tests that the protocol messages can be serialized/deserialized for transport."""
         request = GetMinerIndex()
-        json = request.json()
-        print(json)
-        deserialized = GetMinerIndex.parse_raw(json)
+
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, GetMinerIndex)
         self.assertEqual(request, deserialized)
 
         # Also check that the headers can be constructed.
         request.to_headers()
 
-        # TODO: Add a test for the response.
+        # Now construct a response and check it.
+        response = GetMinerIndex(
+            data_entity_buckets=[
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        time_bucket=TimeBucket(id=5),
+                        label=DataLabel(value="r/bittensor_"),
+                        source=DataSource.REDDIT,
+                    ),
+                    size_bytes=100,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        time_bucket=TimeBucket(id=6),
+                        source=DataSource.X,
+                    ),
+                    size_bytes=200,
+                ),
+            ]
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, GetMinerIndex)
+        self.assertEqual(response, deserialized)
+
+    def test_get_miner_index_new_format_round_trip(self):
+        """Tests that the protocol messages can be serialized/deserialized for transport."""
+
+        request = GetMinerIndex()
+
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, GetMinerIndex)
+        self.assertEqual(request, deserialized)
+
+        # Also check that the headers can be constructed.
+        request.to_headers()
+
+        # Now construct a response and check it.
+        response = GetMinerIndex(
+            data_entity_buckets=[
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        time_bucket=TimeBucket(id=5),
+                        label=DataLabel(value="r/bittensor_"),
+                        source=DataSource.REDDIT,
+                    ),
+                    size_bytes=100,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        time_bucket=TimeBucket(id=6),
+                        source=DataSource.X,
+                    ),
+                    size_bytes=200,
+                ),
+            ]
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, GetMinerIndex)
+        self.assertEqual(response, deserialized)
+
+    def test_old_miner_new_vali_round_trip(self):
+        """Verifies round trip communication betwee a new vali and an old miner"""
+        request = GetMinerIndex()
+
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, old_protocol.GetMinerIndex)
+        # We can't check equality because the new GetMinerIndex includes a version field.
+
+        # Now construct a response from the old miner and deserialize it into the new format.
+        response = old_protocol.GetMinerIndex(
+            data_entity_buckets=[
+                old_data.DataEntityBucket(
+                    id=old_data.DataEntityBucketId(
+                        time_bucket=old_data.TimeBucket(id=5),
+                        label=old_data.DataLabel(value="r/bittensor_"),
+                        source=old_data.DataSource.REDDIT,
+                    ),
+                    size_bytes=100,
+                ),
+                old_data.DataEntityBucket(
+                    id=old_data.DataEntityBucketId(
+                        time_bucket=old_data.TimeBucket(id=6),
+                        source=old_data.DataSource.X,
+                    ),
+                    size_bytes=200,
+                ),
+            ]
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, GetMinerIndex)
+        self.assertEqual(2, len(deserialized.data_entity_buckets))
+        self.assertEqual(
+            DataEntityBucket(
+                id=DataEntityBucketId(
+                    time_bucket=TimeBucket(id=5),
+                    label=DataLabel(value="r/bittensor_"),
+                    source=DataSource.REDDIT,
+                ),
+                size_bytes=100,
+            ),
+            deserialized.data_entity_buckets[0],
+        )
+        self.assertEqual(
+            DataEntityBucket(
+                id=DataEntityBucketId(
+                    time_bucket=TimeBucket(id=6),
+                    source=DataSource.X,
+                ),
+                size_bytes=200,
+            ),
+            deserialized.data_entity_buckets[1],
+        )
+
+    def test_new_miner_old_vali_round_trip(self):
+        """Verifies round trip communication betwee a new miner and an old vali"""
+        request = old_protocol.GetMinerIndex()
+
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, GetMinerIndex)
+        # We can't check equality because the new GetMinerIndex includes a version field.
+
+        # Now construct a response from the old miner and deserialize it into the new format.
+        response = GetMinerIndex(
+            data_entity_buckets=[
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        time_bucket=TimeBucket(id=5),
+                        label=DataLabel(value="r/bittensor_"),
+                        source=DataSource.REDDIT,
+                    ),
+                    size_bytes=100,
+                ),
+                DataEntityBucket(
+                    id=DataEntityBucketId(
+                        time_bucket=TimeBucket(id=6),
+                        source=DataSource.X,
+                    ),
+                    size_bytes=200,
+                ),
+            ]
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, old_protocol.GetMinerIndex)
+        self.assertEqual(2, len(deserialized.data_entity_buckets))
+        self.assertEqual(
+            old_data.DataEntityBucket(
+                id=old_data.DataEntityBucketId(
+                    time_bucket=old_data.TimeBucket(id=5),
+                    label=old_data.DataLabel(value="r/bittensor_"),
+                    source=old_data.DataSource.REDDIT,
+                ),
+                size_bytes=100,
+            ),
+            deserialized.data_entity_buckets[0],
+        )
+        self.assertEqual(
+            old_data.DataEntityBucket(
+                id=old_data.DataEntityBucketId(
+                    time_bucket=old_data.TimeBucket(id=6),
+                    source=old_data.DataSource.X,
+                ),
+                size_bytes=200,
+            ),
+            deserialized.data_entity_buckets[1],
+        )
 
 
 class TestGetDataEntityBucket(unittest.TestCase):
-    def test_synapse_serialization(self):
+    def test_get_data_entity_bucket_round_trip(self):
         """Tests that the protocol messages can be serialized/deserialized for transport."""
         request = GetDataEntityBucket(
             data_entity_bucket_id=DataEntityBucketId(
@@ -36,9 +230,8 @@ class TestGetDataEntityBucket(unittest.TestCase):
                 source=DataSource.REDDIT,
             )
         )
-        json = request.json()
-        print(json)
-        deserialized = GetDataEntityBucket.parse_raw(json)
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, GetDataEntityBucket)
         self.assertEqual(request, deserialized)
 
         # Check that the enum is deserialized correctly
@@ -47,7 +240,281 @@ class TestGetDataEntityBucket(unittest.TestCase):
         # Also check that the headers can be constructed.
         request.to_headers()
 
-        # TODO: Add a test for the response.
+        # Now check the response serialization and deserialization.
+        response = GetDataEntityBucket(
+            data_entity_bucket_id=DataEntityBucketId(
+                time_bucket=TimeBucket(id=500),
+                label=DataLabel(value="r/bittensor_"),
+                source=DataSource.REDDIT,
+            ),
+            data_entities=[
+                DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/1",
+                    datetime=dt.datetime.utcnow(),
+                    source=DataSource.REDDIT,
+                    content=b"abc123",
+                    content_size_bytes=6,
+                ),
+                DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/2",
+                    datetime=dt.datetime.utcnow(),
+                    source=DataSource.REDDIT,
+                    label=DataLabel(value="r/bittensor_"),
+                    content=b"edf",
+                    content_size_bytes=3,
+                ),
+            ],
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, GetDataEntityBucket)
+        self.assertEqual(response, deserialized)
+
+    def test_get_data_entity_bucket_new_miner_old_vali(self):
+        """Tests the wire protocol between a new miner and an old vali."""
+        request = old_protocol.GetDataEntityBucket(
+            data_entity_bucket_id=old_data.DataEntityBucketId(
+                time_bucket=old_data.TimeBucket(id=500),
+                label=old_data.DataLabel(value="r/bittensor_"),
+                source=old_data.DataSource.REDDIT,
+            )
+        )
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, GetDataEntityBucket)
+        self.assertEqual(
+            GetDataEntityBucket(
+                data_entity_bucket_id=DataEntityBucketId(
+                    time_bucket=TimeBucket(500),
+                    label=DataLabel(value="r/bittensor_"),
+                    source=DataSource.REDDIT,
+                )
+            ),
+            deserialized,
+        )
+
+        # Check that the enum is deserialized correctly
+        self.assertEqual(deserialized.data_entity_bucket_id.source, DataSource.REDDIT)
+
+        # Now check the response serialization and deserialization.
+        now = dt.datetime.now(tz=dt.timezone.utc)
+        response = GetDataEntityBucket(
+            data_entity_bucket_id=DataEntityBucketId(
+                time_bucket=TimeBucket(id=500),
+                label=DataLabel(value="r/bittensor_"),
+                source=DataSource.REDDIT,
+            ),
+            data_entities=[
+                DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/1",
+                    datetime=now,
+                    source=DataSource.REDDIT,
+                    content=b"abc123",
+                    content_size_bytes=6,
+                ),
+                DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/2",
+                    datetime=now,
+                    source=DataSource.REDDIT,
+                    label=DataLabel(value="r/bittensor_"),
+                    content=b"edf",
+                    content_size_bytes=3,
+                ),
+            ],
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, old_protocol.GetDataEntityBucket)
+        self.assertEqual(
+            old_data.DataEntityBucketId(
+                time_bucket=old_data.TimeBucket(id=500),
+                label=old_data.DataLabel(value="r/bittensor_"),
+                source=old_data.DataSource.REDDIT,
+            ),
+            deserialized.data_entity_bucket_id,
+        )
+        self.assertEqual(
+            old_data.DataEntity(
+                uri="http://reddit.com/r/bittensor_/post/1",
+                datetime=now,
+                source=DataSource.REDDIT,
+                content=b"abc123",
+                content_size_bytes=6,
+            ),
+            deserialized.data_entities[0],
+        )
+        self.assertEqual(
+            old_data.DataEntity(
+                uri="http://reddit.com/r/bittensor_/post/2",
+                datetime=now,
+                source=DataSource.REDDIT,
+                label=old_data.DataLabel(value="r/bittensor_"),
+                content=b"edf",
+                content_size_bytes=3,
+            ),
+            deserialized.data_entities[1],
+        )
+
+    def test_get_data_entity_bucket_old_miner_new_vali(self):
+        """Tests the wire protocol between a old miner and an old vali."""
+        request = GetDataEntityBucket(
+            data_entity_bucket_id=DataEntityBucketId(
+                time_bucket=TimeBucket(id=500),
+                label=DataLabel(value="r/bittensor_"),
+                source=DataSource.REDDIT,
+            )
+        )
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, old_protocol.GetDataEntityBucket)
+        self.assertEqual(
+            old_protocol.GetDataEntityBucket(
+                data_entity_bucket_id=old_data.DataEntityBucketId(
+                    time_bucket=old_data.TimeBucket(id=500),
+                    label=old_data.DataLabel(value="r/bittensor_"),
+                    source=old_data.DataSource.REDDIT,
+                )
+            ),
+            deserialized,
+        )
+
+        # Check that the enum is deserialized correctly
+        self.assertEqual(deserialized.data_entity_bucket_id.source, DataSource.REDDIT)
+
+        # Now check the response serialization and deserialization.
+        now = dt.datetime.now(tz=dt.timezone.utc)
+        response = old_protocol.GetDataEntityBucket(
+            data_entity_bucket_id=old_data.DataEntityBucketId(
+                time_bucket=old_data.TimeBucket(id=500),
+                label=old_data.DataLabel(value="r/bittensor_"),
+                source=old_data.DataSource.REDDIT,
+            ),
+            data_entities=[
+                old_data.DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/1",
+                    datetime=now,
+                    source=old_data.DataSource.REDDIT,
+                    content=b"abc123",
+                    content_size_bytes=6,
+                ),
+                old_data.DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/2",
+                    datetime=now,
+                    source=old_data.DataSource.REDDIT,
+                    label=old_data.DataLabel(value="r/bittensor_"),
+                    content=b"edf",
+                    content_size_bytes=3,
+                ),
+            ],
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, GetDataEntityBucket)
+        self.assertEqual(
+            DataEntityBucketId(
+                time_bucket=TimeBucket(id=500),
+                label=DataLabel(value="r/bittensor_"),
+                source=DataSource.REDDIT,
+            ),
+            deserialized.data_entity_bucket_id,
+        )
+        self.assertEqual(
+            DataEntity(
+                uri="http://reddit.com/r/bittensor_/post/1",
+                datetime=now,
+                source=DataSource.REDDIT,
+                content=b"abc123",
+                content_size_bytes=6,
+            ),
+            deserialized.data_entities[0],
+        )
+        self.assertEqual(
+            DataEntity(
+                uri="http://reddit.com/r/bittensor_/post/2",
+                datetime=now,
+                source=DataSource.REDDIT,
+                label=DataLabel(value="r/bittensor_"),
+                content=b"edf",
+                content_size_bytes=3,
+            ),
+            deserialized.data_entities[1],
+        )
+
+    def test_get_data_entity_bucket_old_miner_new_vali_no_label(self):
+        """Tests the wire protocol between a old miner and an new vali with no label."""
+        request = GetDataEntityBucket(
+            data_entity_bucket_id=DataEntityBucketId(
+                time_bucket=TimeBucket(id=500),
+                source=DataSource.REDDIT,
+            )
+        )
+        serialized = serialize_like_dendrite(request)
+        deserialized = deserialize(serialized, old_protocol.GetDataEntityBucket)
+        self.assertEqual(
+            old_protocol.GetDataEntityBucket(
+                data_entity_bucket_id=old_data.DataEntityBucketId(
+                    time_bucket=old_data.TimeBucket(id=500),
+                    source=old_data.DataSource.REDDIT,
+                )
+            ),
+            deserialized,
+        )
+
+        # Check that the enum is deserialized correctly
+        self.assertEqual(deserialized.data_entity_bucket_id.source, DataSource.REDDIT)
+
+        # Now check the response serialization and deserialization.
+        now = dt.datetime.now(tz=dt.timezone.utc)
+        response = old_protocol.GetDataEntityBucket(
+            data_entity_bucket_id=old_data.DataEntityBucketId(
+                time_bucket=old_data.TimeBucket(id=500),
+                source=old_data.DataSource.REDDIT,
+            ),
+            data_entities=[
+                old_data.DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/1",
+                    datetime=now,
+                    source=old_data.DataSource.REDDIT,
+                    content=b"abc123",
+                    content_size_bytes=6,
+                ),
+                old_data.DataEntity(
+                    uri="http://reddit.com/r/bittensor_/post/2",
+                    datetime=now,
+                    source=old_data.DataSource.REDDIT,
+                    content=b"edf",
+                    content_size_bytes=3,
+                ),
+            ],
+        )
+
+        serialized = serialize_like_axon(response)
+        deserialized = deserialize(serialized, GetDataEntityBucket)
+        self.assertEqual(
+            DataEntityBucketId(
+                time_bucket=TimeBucket(id=500),
+                source=DataSource.REDDIT,
+            ),
+            deserialized.data_entity_bucket_id,
+        )
+        self.assertEqual(
+            DataEntity(
+                uri="http://reddit.com/r/bittensor_/post/1",
+                datetime=now,
+                source=DataSource.REDDIT,
+                content=b"abc123",
+                content_size_bytes=6,
+            ),
+            deserialized.data_entities[0],
+        )
+        self.assertEqual(
+            DataEntity(
+                uri="http://reddit.com/r/bittensor_/post/2",
+                datetime=now,
+                source=DataSource.REDDIT,
+                content=b"edf",
+                content_size_bytes=3,
+            ),
+            deserialized.data_entities[1],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/storage/miner/test_sqlite_miner_storage.py
+++ b/tests/storage/miner/test_sqlite_miner_storage.py
@@ -88,10 +88,21 @@ class TestSqliteMinerStorage(unittest.TestCase):
         self.test_storage.store_data_entities([entity1, entity2])
 
         # Update the contents
-        entity1.content = bytes(50)
-        entity1.content_size_bytes = 50
-        entity2.content = bytes(100)
-        entity2.content_size_bytes = 100
+        entity1 = DataEntity(
+            uri="test_entity_1",
+            datetime=now,
+            source=DataSource.REDDIT,
+            content=bytes(50),
+            content_size_bytes=50,
+        )
+        entity2 = DataEntity(
+            uri="test_entity_2",
+            datetime=now,
+            source=DataSource.X,
+            label=DataLabel(value="label_2"),
+            content=bytes(100),
+            content_size_bytes=100,
+        )
 
         # Store the entities again.
         self.test_storage.store_data_entities([entity1, entity2])


### PR DESCRIPTION
We have perf issues with the current MinerIndex when the number of buckets gets too large. This change:

1. Removes the use of pydantic models because the validation was making object construction reallly slow
2. Adds a compressed version of the index. A maximal index now requires only 30MB instead of ~400MB

Rough perf stats:
1. Compressing a 3M bucket index takes ~25 seconds
2. Serializing the 3M bucket compressed index ~8 seconds

There's definitely some additional perf wins we can claim if necessary, but since valis allow up to 5 minutes for minerindex queries, these numbers should more than suffice. I'd expect all indexes to take < 1.5 minutes to reach the vali, and another 0.5 minute to deserialize w/ basic validation.

Other notes:
- This only introduces the vali handling of the compressed index. Once valis have updated, we can send the compressed index from miners and remove the uncompressed index.