### PR TITLE
Add an auto-update script for validators

### DIFF
--- a/docs/validator.md
+++ b/docs/validator.md
@@ -59,7 +59,26 @@ Alternatively, you can provide it via the `--neuron.database_password` flag.
 
 ## Running the Validator
 
-For this guide, we'll use [pm2](https://pm2.keymetrics.io/) to manage the Miner process, because it'll restart the Miner if it crashes. If you don't already have it, install pm2.
+### With auto-updates
+
+We highly recommend running the validator with auto-updates. This will help ensure your validator is always running the latest release, helping to maintain a high vtrust.
+
+Prerequisites:
+1. To run with auto-update, you will need to have [pm2](https://pm2.keymetrics.io/) installed.
+2. Make sure your virtual environment is activated. This is important because the auto-updater will automatically update the package dependencies with pip.
+3. Make sure you're using the main branch: `git checkout main`.
+
+From the data-universe folder:
+```shell
+pm2 start --name net13-vali-updater --interpreter python scripts/start_validator.py -- --pm2_name net13-vali --wallet.name cold_wallet --wallet.hotkey hotkey_wallet [other vali flags]
+```
+
+This will start a process called `net13-vali-updater`. This process periodically checks for a new git commit on the current branch. When one is found, it performs a `pip install` for the latest packages, and restarts the validator process (who's name is given by the `--pm2_name` flag)
+
+
+### Without auto-updates
+
+If you'd prefer to manage your own validator updates...
 
 From the data-universe folder:
 ```shell
@@ -81,7 +100,6 @@ python ./neurons/validator.py -h
 
 We are working hard to add more features to the Subnet. For the Validators, we have plans to:
 
-1. Implement an auto-update script.
-2. Have the Validator serve an Axon on the network, so neurons on other Subnets can retrieve data.
-3. Add scrapers for other DataSources.
-4. Add other (and cheaper) scrapers for the Validators to use.
+1. Have the Validator serve an Axon on the network, so neurons on other Subnets can retrieve data.
+2. Add scrapers for other DataSources.
+3. Add other (and cheaper) scrapers for the Validators to use.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-apify-client
-asyncpraw
-bittensor>=6.0
-jupyter
-mysql-connector-python
-numpy
-# Bittensor requires pydantic <2.0.0
-pydantic==1.10
-python-dotenv
-pytz
-torch
+apify-client==1.6.1
+asyncpraw==7.7.1
+bittensor==6.5.0
+jupyter==1.0.0
+mysql-connector-python==8.2.0
+numpy==1.26.2
+# Bittensor require pydantic < 2.0.0
+pydantic==1.10.0
+python-dotenv==1.0.0
+pytz==2023.3.post1
+torch==2.1.2

--- a/scripts/start_validator.py
+++ b/scripts/start_validator.py
@@ -1,0 +1,178 @@
+"""
+This script runs a validator process and automatically updates it when a new version is released.
+Command-line arguments will be forwarded to validator (`neurons/validator.py`), so you can pass
+them like this:
+    python3 scripts/start_validator.py --wallet.name=my-wallet
+Auto-updates are enabled by default and will make sure that the latest version is always running
+by pulling the latest version from git and upgrading python packages. This is done periodically.
+Local changes may prevent the update, but they will be preserved.
+
+To disable auto-updates, pass --no_autoupdate.
+
+The script will use the same virtual environment as the one used to run it. If you want to run
+validator within virtual environment, run this auto-update script from the virtual environment.
+
+Pm2 is required for this script. This script will start a pm2 process using the name provided by
+the --pm2_name argument.
+"""
+import argparse
+import logging
+import subprocess
+import sys
+import time
+from datetime import timedelta
+from pathlib import Path
+from shlex import split
+from typing import List
+
+log = logging.getLogger(__name__)
+# TODO: Switch back to 5 minutes.
+UPDATES_CHECK_TIME = timedelta(minutes=1)
+ROOT_DIR = Path(__file__).parent.parent
+
+
+def get_version() -> str:
+    """Extract the version as current git commit hash"""
+    result = subprocess.run(
+        split("git rev-parse HEAD"),
+        check=True,
+        capture_output=True,
+        cwd=ROOT_DIR,
+    )
+    commit = result.stdout.decode().strip()
+    assert len(commit) == 40, f"Invalid commit hash: {commit}"  # noqa: PLR2004
+    return commit[:8]
+
+
+def start_validator_process(pm2_name: str, args: List[str]) -> subprocess.Popen:
+    """
+    Spawn a new python process running neurons.validator.
+    `sys.executable` ensures thet the same python interpreter is used as the one
+    used to run this auto-updater.
+    """
+    assert sys.executable, "Failed to get python executable"
+
+    log.info("Starting validator process with pm2, name: %s", pm2_name)
+    process = subprocess.Popen(
+        (
+            "pm2",
+            "start",
+            sys.executable,
+            "--name",
+            pm2_name,
+            "--",
+            "-m",
+            "neurons.validator",
+            *args,
+        ),
+        cwd=ROOT_DIR,
+    )
+    process.pm2_name = pm2_name
+
+    return process
+
+
+def stop_validator_process(process: subprocess.Popen) -> None:
+    """Stop the validator process"""
+    subprocess.run(("pm2", "delete", process.pm2_name), cwd=ROOT_DIR, check=True)
+
+
+def pull_latest_version() -> None:
+    """
+    Pull the latest version from git.
+    This uses `git pull --rebase`, so if any changes were made to the local repository,
+    this will try to apply them on top of origin's changes. This is intentional, as we
+    don't want to overwrite any local changes. However, if there are any conflicts,
+    this will abort the rebase and return to the original state.
+    The conflicts are expected to happen rarely since validator is expected
+    to be used as-is.
+    """
+    try:
+        subprocess.run(split("git pull --rebase --autostash"), check=True, cwd=ROOT_DIR)
+    except subprocess.CalledProcessError as exc:
+        log.error("Failed to pull, reverting: %s", exc)
+        subprocess.run(split("git rebase --abort"), check=True, cwd=ROOT_DIR)
+
+
+def upgrade_packages() -> None:
+    """
+    Upgrade python packages by running `pip install --upgrade -r requirements.txt`.
+    Notice: this won't work if some package in `requirements.txt` is downgraded.
+    Ignored as this is unlikely to happen.
+    """
+
+    log.info("Upgrading packages")
+    try:
+        subprocess.run(
+            split(f"{sys.executable} -m pip install -e ."),
+            check=True,
+            cwd=ROOT_DIR,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.error("Failed to upgrade packages, proceeding anyway. %s", exc)
+
+
+def main(pm2_name: str, auto_update: bool, args: List[str]) -> None:
+    """
+    Run the validator process and automatically update it when a new version is released.
+    This will check for updates every `UPDATES_CHECK_TIME` and update the validator
+    if a new version is available. Update is performed as simple `git pull --rebase`.
+    """
+
+    log.info("Starting validator auto-update=%s", auto_update)
+
+    validator = start_validator_process(pm2_name, args)
+    current_version = latest_version = get_version()
+    log.info("Current version: %s", current_version)
+
+    try:
+        while True:
+            if auto_update:
+                pull_latest_version()
+                latest_version = get_version()
+                log.info("Latest version: %s", latest_version)
+
+            if latest_version != current_version:
+                log.info(
+                    "Upgraded to latest version: %s -> %s",
+                    current_version,
+                    latest_version,
+                )
+                upgrade_packages()
+
+                stop_validator_process(validator)
+                validator = start_validator_process(pm2_name, args)
+                current_version = latest_version
+
+            time.sleep(UPDATES_CHECK_TIME.total_seconds())
+
+    finally:
+        stop_validator_process(validator)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Automatically update and restart the validator process when a new version is released.",
+        epilog="Example usage: python start_validator.py --pm2_name 'net13vali' --wallet_name 'wallet1' --wallet_hotkey 'key123' [--no-autoupdate]",
+    )
+
+    parser.add_argument(
+        "--pm2_name", default="net13vali", help="Name of the PM2 process."
+    )
+    parser.add_argument(
+        "--autoupdate",
+        action="store_true",
+        dest="autoupdate",
+        default=True,
+        help="Disable automatic update.",
+    )
+
+    flags, extra_args = parser.parse_known_args()
+
+    main(flags.pm2_name, flags.autoupdate, extra_args)


### PR DESCRIPTION
Performs auto-updates by watching for new commits, updating packages, and then restarting the pm2 process. This assumes every validator uses pm2, which is probably a fair assumption.