### PR TITLE
Return the compressed index from the miner

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -12,8 +12,8 @@ DATA_ENTITY_BUCKET_AGE_LIMIT_DAYS = 30
 # The maximum number of characters a label can have.
 MAX_LABEL_LENGTH = 32
 
-# The current protocol version.
-PROTOCOL_VERSION = 1
+# The current protocol version (int)
+PROTOCOL_VERSION = 2
 
 # Baseline threshold under which score increase limits are not applied.
 SCORE_GROWTH_LIMIT_THRESHOLD = utils.mb_to_bytes(1000)

--- a/common/protocol.py
+++ b/common/protocol.py
@@ -36,7 +36,7 @@ class BaseProtocol(bt.Synapse):
     )
 
 
-class GetMinerIndex(bt.Synapse):
+class GetMinerIndex(BaseProtocol):
     """
     Protocol by which Validators can retrieve the Index from a Miner.
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -23,6 +23,7 @@ import traceback
 import typing
 import bittensor as bt
 from common import utils
+from common.data import CompressedMinerIndex
 from common.protocol import GetDataEntityBucket, GetMinerIndex
 from neurons.config import NeuronType
 from scraping.config.config_reader import ConfigReader
@@ -242,10 +243,11 @@ class Miner(BaseNeuron):
         )
 
         # List all the data entity buckets that this miner currently has.
-        synapse.data_entity_buckets = self.storage.list_data_entity_buckets()
+        compressed_index = self.storage.get_compressed_index()
+        synapse.compressed_index_serialized = compressed_index.json()
 
         bt.logging.debug(
-            f"Returning miner index with size: {len(synapse.data_entity_buckets)}"
+            f"Returning miner index with size: {CompressedMinerIndex.size(compressed_index)}"
         )
 
         return synapse

--- a/storage/miner/miner_storage.py
+++ b/storage/miner/miner_storage.py
@@ -1,6 +1,11 @@
 from abc import ABC, abstractmethod
-from common.data import DataEntity, DataEntityBucket, DataEntityBucketId
+from common.data import (
+    CompressedMinerIndex,
+    DataEntity,
+    DataEntityBucketId,
+)
 from typing import List
+
 
 class MinerStorage(ABC):
     """An abstract class which defines the contract that all implementations of MinerStorage must fulfill."""
@@ -9,13 +14,15 @@ class MinerStorage(ABC):
     def store_data_entities(self, data_entities: List[DataEntity]):
         """Stores any number of DataEntities, making space if necessary."""
         raise NotImplemented
-    
+
     @abstractmethod
-    def list_data_entities_in_data_entity_bucket(self, data_entity_bucket_id: DataEntityBucketId) -> List[DataEntity]:
+    def list_data_entities_in_data_entity_bucket(
+        self, data_entity_bucket_id: DataEntityBucketId
+    ) -> List[DataEntity]:
         """Lists from storage all DataEntities matching the provided DataEntityBucket."""
         raise NotImplemented
 
     @abstractmethod
-    def list_data_entity_buckets(self) -> List[DataEntityBucket]:
+    def get_compressed_index(self) -> CompressedMinerIndex:
         """Lists all DataEntityBuckets for all the DataEntities that this MinerStorage is currently serving."""
         raise NotImplemented

--- a/storage/miner/miner_storage.py
+++ b/storage/miner/miner_storage.py
@@ -24,5 +24,5 @@ class MinerStorage(ABC):
 
     @abstractmethod
     def get_compressed_index(self) -> CompressedMinerIndex:
-        """Lists all DataEntityBuckets for all the DataEntities that this MinerStorage is currently serving."""
+        """Gets the compressed MinedIndex, which is a summary of all of the DataEntities that this MinerStorage is currently serving."""
         raise NotImplemented

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -1,15 +1,17 @@
+from collections import defaultdict
 import threading
 from common import constants, utils
 from common.data import (
+    CompressedEntityBucket,
+    CompressedMinerIndex,
     DataEntity,
-    DataEntityBucket,
     DataEntityBucketId,
     DataLabel,
     DataSource,
     TimeBucket,
 )
 from storage.miner.miner_storage import MinerStorage
-from typing import List
+from typing import Dict, List
 import datetime as dt
 import sqlite3
 import contextlib
@@ -228,8 +230,8 @@ class SqliteMinerStorage(MinerStorage):
             )
             return data_entities
 
-    def list_data_entity_buckets(self) -> List[DataEntityBucket]:
-        """Lists all DataEntityBuckets for all the DataEntities that this MinerStorage is currently serving."""
+    def get_compressed_index(self) -> CompressedMinerIndex:
+        """Gets the compressed MinedIndex, which is a summary of all of the DataEntities that this MinerStorage is currently serving."""
 
         with contextlib.closing(self._create_connection()) as connection:
             cursor = connection.cursor()
@@ -253,7 +255,7 @@ class SqliteMinerStorage(MinerStorage):
                 ],
             )
 
-            data_entity_buckets = []
+            buckets_by_source_by_label = defaultdict(dict)
 
             for row in cursor:
                 # Ensure the miner does not attempt to report more than the max DataEntityBucket size.
@@ -264,24 +266,22 @@ class SqliteMinerStorage(MinerStorage):
                     else row["bucketSize"]
                 )
 
-                # Construct the new DataEntityBucket with all non null columns.
-                data_entity_bucket_id = DataEntityBucketId(
-                    time_bucket=TimeBucket(id=row["timeBucketId"]),
-                    source=DataSource(row["source"]),
+                label = row["label"] if row["label"] != "NULL" else None
+
+                bucket = buckets_by_source_by_label[DataSource(row["source"])].get(
+                    label, CompressedEntityBucket(label=label)
                 )
+                bucket.sizes_bytes.append(size)
+                bucket.time_bucket_ids.append(row["timeBucketId"])
+                buckets_by_source_by_label[DataSource(row["source"])][label] = bucket
 
-                # Add the optional Label field if not null.
-                if row["label"] != "NULL":
-                    data_entity_bucket_id.label = DataLabel(value=row["label"])
-
-                data_entity_bucket = DataEntityBucket(
-                    id=data_entity_bucket_id, size_bytes=size
-                )
-
-                data_entity_buckets.append(data_entity_bucket)
-
-            # If we reach the end of the cursor then return all of the data entity buckets.
-            return data_entity_buckets
+            # Convert the buckets_by_source_by_label into a list of lists of CompressedEntityBucket and return
+            return CompressedMinerIndex(
+                sources={
+                    source: list(labels_to_buckets.values())
+                    for source, labels_to_buckets in buckets_by_source_by_label.items()
+                }
+            )
 
     def clear_content_from_oldest(self, content_bytes_to_clear: int):
         """Deletes entries starting from the oldest until we have cleared the specified amount of content."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Iterable, Tuple
 import time
 import datetime as dt
 
-from common.data import MinerIndex
+from common.data import CompressedMinerIndex, MinerIndex
 from common.data_v2 import ScorableDataEntityBucket, ScorableMinerIndex
 
 
@@ -76,3 +76,28 @@ def are_scorable_indexes_equal(
             )
 
     return True, None
+
+
+def are_compressed_indexes_equal(
+    index1: CompressedMinerIndex, index2: CompressedMinerIndex
+) -> bool:
+    """Compares two CompressedMinerIndex instances for equality."""
+
+    # Iterate both indexes, in order of sources.
+    for source1, source2 in zip(sorted(index1.sources), sorted(index2.sources)):
+        if source1 != source2:
+            print(f"Sources do not match. {source1} != {source2}")
+            return False
+
+        # For a given source, compare the buckets.
+        buckets1 = sorted(
+            index1.sources[source1], key=lambda b: b.label if b.label else "NULL"
+        )
+        buckets2 = sorted(
+            index2.sources[source2], key=lambda b: b.label if b.label else "NULL"
+        )
+        if buckets1 != buckets2:
+            print(f"Buckets do not match. {buckets1} != {buckets2}")
+            return False
+
+    return True


### PR DESCRIPTION
Returns the compressed index from the miner. 

The improvement is stark. 
Before:
- 200k bucket index was 253MB and took ~5 minutes to query and generate

After
- 200k bucket index is 2.9MB and takes ~5 seconds to query and generate