### PR TITLE
Fix the issue with concurrent dendrites

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -20,7 +20,6 @@ import copy
 import datetime
 import sys
 import traceback
-from sympy import N
 import torch
 import asyncio
 import threading

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -20,6 +20,7 @@ import copy
 import datetime
 import sys
 import traceback
+from sympy import N
 import torch
 import asyncio
 import threading
@@ -73,9 +74,6 @@ class Validator(BaseNeuron):
         # Save a copy of the hotkeys to local memory.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
 
-        # Dendrite lets us send messages to other nodes (axons) in the network.
-        self.dendrite = bt.dendrite(wallet=self.wallet)
-
         # Set up initial scoring weights for validation
         self.scorer = MinerScorer(self.metagraph.n, DataValueCalculator())
 
@@ -123,11 +121,13 @@ class Validator(BaseNeuron):
 
         bt.logging.trace(f"{hotkey}: Getting MinerIndex from miner.")
 
-        responses: List[GetMinerIndex] = await self.dendrite.forward(
-            axons=[miner_axon],
-            synapse=GetMinerIndex(),
-            timeout=300,
-        )
+        responses: List[GetMinerIndex] = None
+        async with bt.dendrite(wallet=self.wallet) as dendrite:
+            responses = await dendrite.forward(
+                axons=[miner_axon],
+                synapse=GetMinerIndex(),
+                timeout=300,
+            )
 
         response = vali_utils.get_single_successful_response(responses, GetMinerIndex)
         if not response:
@@ -225,13 +225,15 @@ class Validator(BaseNeuron):
             f"{hotkey} Querying miner for chunk {chosen_data_entity_bucket}"
         )
 
-        responses = await self.dendrite.forward(
-            axons=[axon_info],
-            synapse=GetDataEntityBucket(
-                data_entity_bucket_id=chosen_data_entity_bucket.id
-            ),
-            timeout=180,
-        )
+        responses = None
+        async with bt.dendrite(wallet=self.wallet) as dendrite:
+            responses = await dendrite.forward(
+                axons=[axon_info],
+                synapse=GetDataEntityBucket(
+                    data_entity_bucket_id=chosen_data_entity_bucket.id
+                ),
+                timeout=180,
+            )
 
         data_entity_bucket = vali_utils.get_single_successful_response(
             responses, GetDataEntityBucket


### PR DESCRIPTION
We were occasionally seeing errors in the vali when sending GetDataEntityBucket requests: "Can not write request body". It turns out, the issue was due to using a single dendrite for multiple requests in parallel.