### PR TITLE
Change the log level of two lines that are important for miners

### DIFF
--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -38,7 +38,7 @@ def validate_reddit_content(
         )
 
     if actual_content != content_to_validate:
-        bt.logging.trace(
+        bt.logging.info(
             f"RedditContent does not match: {actual_content} != {content_to_validate}"
         )
         return ValidationResult(

--- a/scraping/x/twitter_flash_scraper.py
+++ b/scraping/x/twitter_flash_scraper.py
@@ -191,7 +191,7 @@ class TwitterFlashScraper(Scraper):
             )
 
         if tweet_to_verify != tweet:
-            bt.logging.trace(f"Tweets do not match: {tweet_to_verify} != {tweet}.")
+            bt.logging.info(f"Tweets do not match: {tweet_to_verify} != {tweet}.")
             return ValidationResult(
                 is_valid=False,
                 reason="Tweet does not match",


### PR DESCRIPTION
Some of the validators are logging to wandb with trace enabled, but others aren't. These lines are critical for miners to know if they've messed up formatting of any data that is being sent to the validators.