### PR TITLE
Implement a MetagraphSyncer to sync multiple metagraphs

### DIFF
--- a/common/metagraph_syncer.py
+++ b/common/metagraph_syncer.py
@@ -1,0 +1,145 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import dataclasses
+from dataclasses import field
+from datetime import datetime
+import functools
+import bittensor as bt
+from typing import Dict, List, Callable, Optional
+import threading
+import traceback
+
+from common import utils
+
+
+class MetagraphSyncer:
+    @dataclasses.dataclass
+    class _State:
+        metagraph: Optional[bt.metagraph] = None
+        last_synced_time: Optional[datetime] = None
+        listeners: List = field(default_factory=list)
+
+    def __init__(self, subtensor: bt.subtensor, config: Dict[int, int]):
+        """Constructs a new MetagraphSyncer, that periodically refreshes metagraph defined in the config.
+
+        Args:
+            subtensor (bt.subtensor): The subtensor used to fetch the metagraphs.
+            config (Dict[int, int]): A mapping of netuid to the cadence (in seconds) to sync the metagraph.
+        """
+        self.subtensor = subtensor
+        self.config = config
+        self.metagraph_map: Dict[int, MetagraphSyncer._State] = {
+            netuid: MetagraphSyncer._State() for netuid in config.keys()
+        }
+        self.is_running = False
+        self.done_initial_sync = False
+        self.lock = threading.RLock()
+        self.notify_listener_thrad_pool = ThreadPoolExecutor(max_workers=1)
+
+    def do_initial_sync(self):
+        """Performs an initial sync of all metagraphs.
+
+        Unlike regular syncs, this will not notify listeners of the updated metagraph.
+        """
+        bt.logging.debug("Metagraph syncer do_initial_sync called")
+
+        for netuid in self.config.keys():
+            fn = functools.partial(self.subtensor.metagraph, netuid)
+            with self.lock:
+                metagraph = utils.run_in_subprocess(fn, ttl=120)
+                state = self.metagraph_map[netuid]
+                state.metagraph = metagraph
+                state.last_synced_time = datetime.now()
+
+            bt.logging.debug(f"Successfully loaded metagraph for {netuid}")
+
+        self.done_initial_sync = True
+
+    def start(self):
+        bt.logging.debug("Metagraph syncer start called")
+
+        assert self.done_initial_sync, "Must call do_initial_sync before starting"
+
+        self.is_running = True
+        thread = threading.Thread(target=self._run, daemon=True)
+        thread.start()
+
+    async def _sync_metagraph_loop(self, netuid: int, cadence: int):
+        while self.is_running:
+            # On start, wait cadence before the first sync.
+            await asyncio.sleep(cadence)
+
+            try:
+                # Intentionally block the shared thread so that we only
+                # sync 1 metagraph at a time.
+                metagraph = utils.run_in_subprocess(
+                    functools.partial(self.subtensor.metagraph, netuid), ttl=120
+                )
+                state = None
+                with self.lock:
+                    # Store metagraph and sync time
+                    state = self.metagraph_map[netuid]
+                    state.metagraph = metagraph
+                    state.last_synced_time = datetime.now()
+
+                await self._notify_listeners(state, netuid)
+
+                await asyncio.sleep(cadence)
+            except (BaseException, Exception) as e:
+                bt.logging.error(
+                    f"Error when syncing metagraph for {netuid}: {e}. Retrying in 60 seconds."
+                )
+                await asyncio.sleep(60)
+
+    def _run(self):
+        # For each netuid we should sync metagraphs for, spawn a Task to sync it.
+        asyncio.gather(
+            [
+                self._sync_metagraph_loop(netuid, cadence)
+                for netuid, cadence in self.config.items()
+            ]
+        )
+        bt.logging.info("MetagraphSyncer _run complete.")
+
+    def register_listener(
+        self, listener: Callable[[bt.metagraph, int], None], netuids: List[int]
+    ):
+        """Registers a listener to be notified when a metagraph for any netuid in netuids is updated.
+
+        The listener will be called from a different thread, so it must be thread-safe.
+        """
+        if not netuids:
+            raise ValueError("Must provide at least 1 netuid")
+
+        with self.lock:
+            for netuid in netuids:
+                if netuid not in self.metagraph_map:
+                    raise ValueError(
+                        f"Metagraph for {netuid} not being tracked in MetagraphSyncer."
+                    )
+                self.metagraph_map[netuid].listeners.append(listener)
+
+    def get_metagraph(self, netuid: int) -> bt.metagraph:
+        """Returns the last synced version of the metagraph for netuid."""
+        with self.lock:
+            if netuid not in self.metagraph_map:
+                raise ValueError(
+                    f"Metagraph for {netuid} not known to MetagraphSyncer."
+                )
+            metagraph = self.metagraph_map[netuid].metagraph
+            if not metagraph:
+                raise ValueError(f"Metagraph for {netuid} has not been synced yet.")
+            return metagraph
+
+    async def _notify_listeners(self, state: _State, netuid: int):
+        """Notifies listeners of a new metagraph for netuid."""
+
+        for listener in state.listeners:
+            try:
+                await self.notify_listener_thrad_pool.submit(
+                    listener(state.metagraph, netuid)
+                )
+            except Exception:
+                bt.logging.error(
+                    f"Exception caught notifying {netuid} listener of metagraph update.\n{traceback.format_exc()}"
+                )

--- a/common/utils.py
+++ b/common/utils.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import datetime as dt
+import functools
+import multiprocessing
 import pickle
 from socket import timeout
 import time
@@ -207,3 +209,53 @@ async def async_run_with_retry(
             # Wait before the next retry.
             time.sleep(delay_seconds)
     raise Exception("Unexpected state: Ran with retry but didn't hit a terminal state")
+
+
+def run_in_subprocess(func: functools.partial, ttl: int) -> Any:
+    """Runs the provided function on a subprocess with 'ttl' seconds to complete.
+
+    Args:
+        func (functools.partial): Function to be run.
+        ttl (int): How long to try for in seconds.
+
+    Returns:
+        Any: The value returned by 'func'
+    """
+
+    def wrapped_func(func: functools.partial, queue: multiprocessing.Queue):
+        try:
+            print(f"In subprocess")
+            result = func()
+            print("Putting result into queue")
+            queue.put(result)
+            print("Put thingy into the queue")
+        except (Exception, BaseException) as e:
+            # Catch exceptions here to add them to the queue.
+            queue.put(e)
+
+    # Use "fork" (the default on all POSIX except macOS), because pickling doesn't seem
+    # to work on "spawn".
+    ctx = multiprocessing.get_context("fork")
+    queue = ctx.Queue()
+    process = ctx.Process(target=wrapped_func, args=[func, queue])
+
+    process.start()
+
+    process.join(timeout=ttl)
+
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        raise TimeoutError(f"Failed to {func.func.__name__} after {ttl} seconds")
+
+    # Raises an error if the queue is empty. This is fine. It means our subprocess timed out.
+    print("Pulling from the queue")
+    result = queue.get(block=False)
+
+    # If we put an exception on the queue then raise instead of returning.
+    if isinstance(result, Exception):
+        raise result
+    if isinstance(result, BaseException):
+        raise Exception(f"BaseException raised in subprocess: {str(result)}")
+
+    return result

--- a/tests/common/test_metagraph_syncer.py
+++ b/tests/common/test_metagraph_syncer.py
@@ -1,0 +1,77 @@
+from curses import meta
+import threading
+from unittest import mock
+import unittest
+import bittensor as bt
+from common.metagraph_syncer import MetagraphSyncer
+
+
+class TestMetagraphSyncer(unittest.TestCase):
+    def test_do_initial_sync(self):
+        # Mock subtensor.metagraph() function
+        metagraph1 = bt.metagraph(netuid=1, sync=False)
+        metagraph2 = bt.metagraph(netuid=2, sync=False)
+
+        def get_metagraph(netuid) -> bt.metagraph:
+            if netuid == 1:
+                return metagraph1
+            elif netuid == 2:
+                return metagraph2
+            else:
+                raise Exception("Invalid netuid")
+
+        mock_subtensor = mock.MagicMock(spec=bt.subtensor)
+        metagraph_mock = mock.MagicMock(side_effect=get_metagraph)
+        mock_subtensor.metagraph = metagraph_mock
+
+        # Create MetagraphSyncer instance with mock subtensor
+        metagraph_syncer = MetagraphSyncer(mock_subtensor, {1: 1, 2: 1})
+
+        # Call do_initial_sync method
+        metagraph_syncer.do_initial_sync()
+
+        # Verify get_metagraph() returns the expected metagraph.
+        # We can't check object equality because of how equality is done on bt.metagraph
+        # so just check the netuid.
+        self.assertEqual(metagraph_syncer.get_metagraph(1).netuid, metagraph1.netuid)
+        self.assertEqual(metagraph_syncer.get_metagraph(2).netuid, metagraph2.netuid)
+
+    def test_listener_called(self):
+        # Mock subtensor.metagraph() function
+        metagraph1 = bt.metagraph(netuid=1, sync=False)
+        metagraph2 = bt.metagraph(netuid=2, sync=False)
+
+        def get_metagraph(netuid) -> bt.metagraph:
+            if netuid == 1:
+                return metagraph1
+            elif netuid == 2:
+                return metagraph2
+            else:
+                raise Exception("Invalid netuid")
+
+        mock_subtensor = mock.MagicMock(spec=bt.subtensor)
+        metagraph_mock = mock.MagicMock(side_effect=get_metagraph)
+        mock_subtensor.metagraph = metagraph_mock
+
+        # Create MetagraphSyncer instance with mock subtensor
+        metagraph_syncer = MetagraphSyncer(mock_subtensor, {1: 1, 2: 1})
+
+        # Call do_initial_sync method
+        metagraph_syncer.do_initial_sync()
+
+        # Register a listener for netuid 1.
+        event = threading.Event()
+
+        def listener(metagraph, netuid):
+            self.assertEqual(metagraph.netuid, 1)
+            self.assertEqual(netuid, 1)
+            event.set()
+
+        metagraph_syncer.register_listener(listener, [1])
+
+        # Since we sync every 1 second, verify the listener is called within 5 seconds.
+        event.wait(5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,0 +1,57 @@
+import functools
+import time
+import unittest
+
+from common.utils import run_in_subprocess
+
+
+class TestUtils(unittest.TestCase):
+    def test_run_in_subprocess(self):
+        def test_func(a: int, b: int):
+            return a + b
+
+        partial = functools.partial(test_func, 1, 2)
+
+        result = run_in_subprocess(func=partial, ttl=5)
+        self.assertEqual(3, result)
+
+    def test_run_in_subprocess_timeout(self):
+        def test_func(a: int, b: int):
+            time.sleep(3)
+            return a + b
+
+        partial = functools.partial(test_func, 1, 2)
+
+        with self.assertRaises(TimeoutError):
+            result = run_in_subprocess(func=partial, ttl=1)
+
+    def test_run_in_subprocess_no_return(self):
+        def test_func(a: int, b: int):
+            pass
+
+        partial = functools.partial(test_func, 1, 2)
+
+        result = run_in_subprocess(func=partial, ttl=5)
+        self.assertIsNone(result)
+
+    def test_run_in_subprocess_tuple_return(self):
+        def test_func(a: int, b: int):
+            return a, b
+
+        partial = functools.partial(test_func, 1, 2)
+
+        result = run_in_subprocess(func=partial, ttl=5)
+        self.assertEqual((1, 2), result)
+
+    def test_run_in_subprocess_exception(self):
+        def test_func(a: int, b: int):
+            raise ValueError()
+
+        partial = functools.partial(test_func, 1, 2)
+
+        with self.assertRaises(ValueError):
+            result = run_in_subprocess(func=partial, ttl=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
At the moment, this change is a no-op since it's not integrated into the miner or vali. I'll integrate it in a separate change since it'll require a sizable refactoring of the vali.