### PR TITLE
Cache the compressed miner index.

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -29,6 +29,9 @@ SCORE_GROWTH_LIMIT_PERCENT = 1.05
 # Min evaluation period that must pass before a validator re-evaluates a miner.
 MIN_EVALUATION_PERIOD = datetime.timedelta(minutes=60)
 
+# Miner compressed index cache freshness.
+MINER_CACHE_FRESHNESS = datetime.timedelta(minutes=20)
+
 # Datetime after which DataEntity content field has lower granularity dates.
 REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD = datetime.datetime(
     year=2024, month=3, day=1, tzinfo=datetime.timezone.utc

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -289,14 +289,10 @@ class Miner:
                 compressed_index = self.storage.get_compressed_index(
                     bucket_count_limit=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX_PROTOCOL_4
                 )
-            elif synapse.version == 3:
-                compressed_index = self.storage.get_compressed_index(
-                    bucket_count_limit=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX_PROTOCOL_3
-                )
+            # Only synapse.version 4 is supported at this time.
             else:
-                compressed_index = self.storage.get_compressed_index(
-                    bucket_count_limit=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX
-                )
+                bt.logging.error(f"Unsupported protocol version: {synapse.version}.")
+
             synapse.compressed_index_serialized = compressed_index.json()
             bt.logging.success(
                 f"Returning compressed miner index of {CompressedMinerIndex.size_bytes(compressed_index)} bytes "

--- a/storage/miner/miner_storage.py
+++ b/storage/miner/miner_storage.py
@@ -5,6 +5,7 @@ from common.data import (
     DataEntityBucketId,
 )
 from typing import List
+import datetime as dt
 
 
 class MinerStorage(ABC):
@@ -25,4 +26,9 @@ class MinerStorage(ABC):
     @abstractmethod
     def get_compressed_index(self) -> CompressedMinerIndex:
         """Gets the compressed MinedIndex, which is a summary of all of the DataEntities that this MinerStorage is currently serving."""
+        raise NotImplemented
+
+    @abstractmethod
+    def refresh_compressed_index(self, date_time: dt.timedelta):
+        """Refreshes the compressed MinerIndex."""
         raise NotImplemented

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -254,7 +254,9 @@ class SqliteMinerStorage(MinerStorage):
         # Refresh thread using a 20 minute freshness period and calling this method every 21 minutes.
         with self.cached_index_lock:
             if dt.datetime.now() - self.cached_index_updated <= time_delta:
-                bt.logging.trace(f"Cached index within {time_delta} freshness period.")
+                bt.logging.trace(
+                    f"Skipping updating cached index. It is already fresher than {time_delta}."
+                )
                 return
             else:
                 bt.logging.info(
@@ -330,7 +332,7 @@ class SqliteMinerStorage(MinerStorage):
         self,
         bucket_count_limit=constants.DATA_ENTITY_BUCKET_COUNT_LIMIT_PER_MINER_INDEX_PROTOCOL_4,
     ) -> CompressedMinerIndex:
-        """Gets the compressed MinedIndex, which is a summary of all of the DataEntities that this MinerStorage is currently serving."""
+        """Gets the compressed MinerIndex, which is a summary of all of the DataEntities that this MinerStorage is currently serving."""
 
         # Force refresh index if 10 minutes beyond refersh period. Expected to be refreshed earlier by refresh loop.
         self.refresh_compressed_index(

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -99,6 +99,9 @@ class SqliteMinerStorage(MinerStorage):
             # Create the Index (if it does not already exist).
             cursor.execute(SqliteMinerStorage.DATA_ENTITY_TABLE_INDEX)
 
+            # Use Write Ahead Logging to avoid blocking reads.
+            cursor.execute("pragma journal_mode=wal")
+
         # Lock to avoid concurrency issues on clearing space when full
         self.clearing_space_lock = threading.Lock()
 


### PR DESCRIPTION
Validators are forced to protocol 4 based on minimum version to set weights. Miners will now only support returning a protocol 4 350k compressed index.

The Miner sqlite db is switched to use WAL over a journal. This removes the need to lock on reads.

The Miner now caches the compressed miner index response and refreshes that cache off the hot path.