### PR TITLE
Improve the performance of scoring an index

### DIFF
--- a/rewards/data.py
+++ b/rewards/data.py
@@ -41,6 +41,19 @@ class DataSourceDesirability(StrictBaseModel):
                 )
         return value
 
+    @classmethod
+    def to_primitive_data_source_desirability(
+        cls, obj: "DataSourceDesirability"
+    ) -> "PrimitiveDataSourceDesirability":
+        return PrimitiveDataSourceDesirability(
+            weight=obj.weight,
+            default_scale_factor=obj.default_scale_factor,
+            label_scale_factors={
+                label.value if label else None: scale_factor
+                for label, scale_factor in obj.label_scale_factors.items()
+            },
+        )
+
 
 class DataDesirabilityLookup(StrictBaseModel):
     """Information about data desirability across data sources."""
@@ -71,3 +84,57 @@ class DataDesirabilityLookup(StrictBaseModel):
         ):
             raise ValueError("The data source weights must sum to 1.0")
         return distribution
+
+    @classmethod
+    def to_primitive_data_desirability_lookup(
+        cls, obj: "DataDesirabilityLookup"
+    ) -> "PrimitiveDataDesirabilityLookup":
+        return PrimitiveDataDesirabilityLookup(
+            distribution={
+                data_source: DataSourceDesirability.to_primitive_data_source_desirability(
+                    data_source_reward
+                )
+                for data_source, data_source_reward in obj.distribution.items()
+            },
+            max_age_in_hours=obj.max_age_in_hours,
+        )
+
+
+class PrimitiveDataSourceDesirability(StrictBaseModel):
+    """The Desirability for a data source, using primitive objects for performance"""
+
+    # Makes the object "Immutable" once created.
+    model_config = ConfigDict(frozen=True)
+
+    weight: float = Field(
+        ge=0,
+        le=1,
+        description="The percentage of total reward that is allocated to this data source.",
+    )
+
+    default_scale_factor: float = Field(
+        ge=-1,
+        le=1,
+        default=1.0,
+        description="The scaling factor used for all Labels that aren't explicitly set in label_scale_factors.",
+    )
+
+    label_scale_factors: Dict[str, float] = Field(
+        description="The scaling factor used for each Label. If a Label is not present, the default_scale_factor is used. The values must be between -1 and 1, inclusive.",
+        default_factory=lambda: {},
+    )
+
+
+class PrimitiveDataDesirabilityLookup(StrictBaseModel):
+    """A DataDesirabilityLookup using primitives, for performance."""
+
+    # Makes the object "Immutable" once created.
+    model_config = ConfigDict(frozen=True)
+
+    distribution: Dict[DataSource, PrimitiveDataSourceDesirability] = Field(
+        description="The Desirability for each data source. All data sources must be present and the sum of weights must equal 1.0."
+    )
+
+    max_age_in_hours: PositiveInt = Field(
+        description="The maximum age of data that will receive rewards. Data older than this will score 0",
+    )

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -2,7 +2,9 @@ import threading
 from typing import List, Optional
 import torch
 import bittensor as bt
+import datetime as dt
 from common import constants
+from common.data import TimeBucket
 
 from common.data_v2 import ScorableMinerIndex
 from rewards.data_value_calculator import DataValueCalculator
@@ -132,9 +134,12 @@ class MinerScorer:
 
                 # Now score the miner based on the amount of data it has, scaled based on
                 # the reward distribution.
+                current_time_bucket = TimeBucket.from_datetime(
+                    dt.datetime.now(tz=dt.timezone.utc)
+                )
                 for bucket in index.scorable_data_entity_buckets:
                     score += self.value_calculator.get_score_for_data_entity_bucket(
-                        bucket
+                        bucket, current_time_bucket
                     )
 
                 # Scale the miner's score by its credibility, squared.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,13 @@
+import random
 from typing import Any, Callable, Iterable, Tuple
 import time
 import datetime as dt
 
-from common.data import CompressedMinerIndex, MinerIndex
+from common.data import (
+    CompressedMinerIndex,
+    DataSource,
+    MinerIndex,
+)
 from common.data_v2 import ScorableDataEntityBucket, ScorableMinerIndex
 
 
@@ -125,3 +130,31 @@ def are_compressed_indexes_equal(
             return False
 
     return True
+
+
+def create_scorable_index(num_buckets: int) -> ScorableMinerIndex:
+    """Creates a CompressedMinerIndex with ~ the specified number of buckets."""
+    assert num_buckets > 1000
+
+    labels = [f"label{i}" for i in range(num_buckets // 2 // 500)]
+    time_buckets = [i for i in range(1, (num_buckets // 2 // len(labels)) + 1)]
+
+    # Split max buckets equaly between sources with reddit having 100 time buckets and x having 500.
+    buckets = []
+    for source in [DataSource.REDDIT.value, DataSource.X.value]:
+        for time_bucket in time_buckets:
+            for label in labels:
+                size = random.randint(50, 1000)
+                scorable_bytes = int(random.random() * size)
+                buckets.append(
+                    ScorableDataEntityBucket(
+                        time_bucket_id=time_bucket,
+                        source=source,
+                        label=label,
+                        size_bytes=size,
+                        scorable_bytes=scorable_bytes,
+                    )
+                )
+    return ScorableMinerIndex(
+        scorable_data_entity_buckets=buckets, last_updated=dt.datetime.now()
+    )


### PR DESCRIPTION
In local testing, this change decreased the time to score 350k buckets from ~25 seconds to 0.2 seconds.

In order of the largest benefits: 
1. Only read the current timestamp once, instead of on every bucket
2. Use primitives instead of pydantic objects
