### PR TITLE
Remove all conditional date obfuscation code

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -38,8 +38,3 @@ MIN_EVALUATION_PERIOD = datetime.timedelta(minutes=60)
 
 # Miner compressed index cache freshness.
 MINER_CACHE_FRESHNESS = datetime.timedelta(minutes=20)
-
-# Datetime after which DataEntity content field has lower granularity dates.
-REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD = datetime.datetime(
-    year=2024, month=3, day=1, tzinfo=datetime.timezone.utc
-)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -392,17 +392,6 @@ class Miner:
             )
             return synapse
 
-        # Check that none of the requested buckets are before the content obfuscation time start.
-        minimum_time_bucket = TimeBucket.from_datetime(
-            constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-        )
-        for id in synapse.data_entity_bucket_ids:
-            if id.time_bucket.id < minimum_time_bucket.id:
-                bt.logging.warning(
-                    f"Rejecting GetContentsByBuckets request from {synapse.dendrite.hotkey} at {synapse.dendrite.ip} for requesting a data entity bucket: {id} before {constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD}."
-                )
-                return synapse
-
         # Get a dict of all the contents by DataEntityBucketId for the requested Buckets.
         buckets_to_contents = self.storage.list_contents_in_data_entity_buckets(
             synapse.data_entity_bucket_ids

--- a/scraping/reddit/model.py
+++ b/scraping/reddit/model.py
@@ -52,15 +52,12 @@ class RedditContent(BaseModel):
     )
 
     @classmethod
-    def to_data_entity(
-        cls, content: "RedditContent", obfuscate_content_date: bool
-    ) -> DataEntity:
+    def to_data_entity(cls, content: "RedditContent") -> DataEntity:
         """Converts the RedditContent to a DataEntity."""
         entity_created_at = content.created_at
-        if obfuscate_content_date:
-            content.created_at = utils.obfuscate_datetime_to_minute(entity_created_at)
-
+        content.created_at = utils.obfuscate_datetime_to_minute(entity_created_at)
         content_bytes = content.json(by_alias=True).encode("utf-8")
+
         return DataEntity(
             uri=content.url,
             datetime=entity_created_at,

--- a/scraping/reddit/reddit_custom_scraper.py
+++ b/scraping/reddit/reddit_custom_scraper.py
@@ -120,16 +120,10 @@ class RedditCustomScraper(Scraper):
                 continue
 
             # We found the Reddit content. Validate it.
-            require_obfuscation = (
-                content.created_at
-                >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-            )
-
             results.append(
                 validate_reddit_content(
                     actual_content=content,
                     entity_to_validate=entity,
-                    require_obfuscated_content_date=require_obfuscation,
                 )
             )
 
@@ -213,15 +207,7 @@ class RedditCustomScraper(Scraper):
 
         data_entities = []
         for content in parsed_contents:
-            require_obfuscation = (
-                content.created_at
-                >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-            )
-            data_entities.append(
-                RedditContent.to_data_entity(
-                    content=content, obfuscate_content_date=require_obfuscation
-                )
-            )
+            data_entities.append(RedditContent.to_data_entity(content=content))
 
         return data_entities
 

--- a/scraping/reddit/reddit_lite_scraper.py
+++ b/scraping/reddit/reddit_lite_scraper.py
@@ -124,16 +124,10 @@ class RedditLiteScraper(Scraper):
             # We found the Reddit content. Validate it.
             actual_content = items[0]
 
-            require_obfuscation = (
-                actual_content.created_at
-                >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-            )
-
             results.append(
                 validate_reddit_content(
                     actual_content=actual_content,
                     entity_to_validate=entity,
-                    require_obfuscated_content_date=require_obfuscation,
                 )
             )
 
@@ -203,15 +197,7 @@ class RedditLiteScraper(Scraper):
 
         data_entities = []
         for content in contents:
-            require_obfuscation = (
-                content.created_at
-                >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-            )
-            data_entities.append(
-                RedditContent.to_data_entity(
-                    content=content, obfuscate_content_date=require_obfuscation
-                )
-            )
+            data_entities.append(RedditContent.to_data_entity(content=content))
 
         return data_entities
 

--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -94,18 +94,6 @@ def validate_reddit_content(
             content_size_bytes_validated=entity_to_validate.content_size_bytes,
         )
 
-    # Check Reddit created_at.
-    # Timestamps on the entities must match the reddit submission/post exactly to the second.
-    if actual_content.created_at != entity_to_validate.datetime:
-        bt.logging.info(
-            f"Reddit and Entity timestamps do not match to the second: {entity_to_validate.datetime} != {actual_content.created_at}"
-        )
-        return ValidationResult(
-            is_valid=False,
-            reason="Reddit and Entity timestamps do not match to the second",
-            content_size_bytes_validated=entity_to_validate.content_size_bytes,
-        )
-
     # Timestamps on the contents within the entities must be obfuscated to the minute.
     # If checking an data entity with obfuscated content we compare to the entity directly instead.
     actual_content_obfuscated = utils.obfuscate_datetime_to_minute(

--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -24,7 +24,6 @@ def is_valid_reddit_url(url: str) -> bool:
 def validate_reddit_content(
     actual_content: RedditContent,
     entity_to_validate: DataEntity,
-    require_obfuscated_content_date: bool,
 ) -> ValidationResult:
     """Verifies the RedditContent is valid by the definition provided by entity."""
     content_to_validate = None
@@ -95,23 +94,34 @@ def validate_reddit_content(
             content_size_bytes_validated=entity_to_validate.content_size_bytes,
         )
 
-    # Check Reddit created_at
-    # If checking an data entity with obfuscated content we compare to the entity directly instead.
-    if require_obfuscated_content_date:
-        actual_content_obfuscated = utils.obfuscate_datetime_to_minute(
-            actual_content.created_at
+    # Check Reddit created_at.
+    # Timestamps on the entities must match the reddit submission/post exactly to the second.
+    if actual_content.created_at != entity_to_validate.datetime:
+        bt.logging.info(
+            f"Reddit and Entity timestamps do not match to the second: {entity_to_validate.datetime} != {actual_content.created_at}"
         )
-        if content_to_validate.created_at != actual_content_obfuscated:
+        return ValidationResult(
+            is_valid=False,
+            reason="Reddit and Entity timestamps do not match to the second",
+            content_size_bytes_validated=entity_to_validate.content_size_bytes,
+        )
+
+    # Timestamps on the contents within the entities must be obfuscated to the minute.
+    # If checking an data entity with obfuscated content we compare to the entity directly instead.
+    actual_content_obfuscated = utils.obfuscate_datetime_to_minute(
+        actual_content.created_at
+    )
+    if content_to_validate.created_at != actual_content_obfuscated:
+        if content_to_validate.created_at == actual_content.created_at:
             bt.logging.info(
-                f"Reddit timestamps do not match: {actual_content} != {content_to_validate}"
+                f"Provided Reddit content datetime was not obfuscated to the minute as required: {actual_content} != {content_to_validate}"
             )
             return ValidationResult(
                 is_valid=False,
-                reason="Reddit timestamps do not match",
+                reason="Provided Reddit content datetime was not obfuscated to the minute as required",
                 content_size_bytes_validated=entity_to_validate.content_size_bytes,
             )
-    else:
-        if content_to_validate.created_at != actual_content.created_at:
+        else:
             bt.logging.info(
                 f"Reddit timestamps do not match: {actual_content} != {content_to_validate}"
             )
@@ -183,10 +193,7 @@ def validate_reddit_content(
     # Wahey! The content is valid.
     # One final check. Does the Reddit content match the data entity information?
     try:
-        # It does not matter if we obfuscate the content here since we only check non content.
-        actual_entity = RedditContent.to_data_entity(
-            content=actual_content, obfuscate_content_date=False
-        )
+        actual_entity = RedditContent.to_data_entity(content=actual_content)
 
         # Extra check that the content size is reasonably close to what we expect.
         # Allow a 10 byte difference to account for timestamp serialization differences.

--- a/scraping/x/microworlds_scraper.py
+++ b/scraping/x/microworlds_scraper.py
@@ -105,14 +105,9 @@ class MicroworldsTwitterScraper(Scraper):
                             content_size_bytes_validated=entity.content_size_bytes,
                         )
                 else:
-                    require_obfuscation = (
-                        actual_tweet.timestamp
-                        >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-                    )
                     return utils.validate_tweet_content(
                         actual_tweet=actual_tweet,
                         entity=entity,
-                        require_obfuscated_content_date=require_obfuscation,
                     )
 
         if not entities:
@@ -181,15 +176,7 @@ class MicroworldsTwitterScraper(Scraper):
         data_entities = []
 
         for x_content in x_contents:
-            require_obfuscation = (
-                x_content.timestamp
-                >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-            )
-            data_entities.append(
-                XContent.to_data_entity(
-                    content=x_content, obfuscate_content_date=require_obfuscation
-                )
-            )
+            data_entities.append(XContent.to_data_entity(content=x_content))
 
         return data_entities
 

--- a/scraping/x/model.py
+++ b/scraping/x/model.py
@@ -32,15 +32,12 @@ class XContent(BaseModel):
     )
 
     @classmethod
-    def to_data_entity(
-        cls, content: "XContent", obfuscate_content_date: bool
-    ) -> DataEntity:
+    def to_data_entity(cls, content: "XContent") -> DataEntity:
         """Converts the XContent to a DataEntity."""
         entity_timestamp = content.timestamp
-        if obfuscate_content_date:
-            content.timestamp = utils.obfuscate_datetime_to_minute(entity_timestamp)
-
+        content.timestamp = utils.obfuscate_datetime_to_minute(entity_timestamp)
         content_bytes = content.json(exclude_none=True).encode("utf-8")
+
         return DataEntity(
             uri=content.url,
             datetime=entity_timestamp,

--- a/scraping/x/quacker_url_scraper.py
+++ b/scraping/x/quacker_url_scraper.py
@@ -101,15 +101,10 @@ class QuackerUrlScraper(Scraper):
                 )
                 continue
 
-            require_obfuscation = (
-                actual_tweet.timestamp
-                >= constants.REDUCED_CONTENT_DATETIME_GRANULARITY_THRESHOLD
-            )
             results.append(
                 utils.validate_tweet_content(
                     actual_tweet=actual_tweet,
                     entity=entity,
-                    require_obfuscated_content_date=require_obfuscation,
                 )
             )
 

--- a/scraping/x/utils.py
+++ b/scraping/x/utils.py
@@ -122,18 +122,6 @@ def validate_tweet_content(
             content_size_bytes_validated=entity.content_size_bytes,
         )
 
-    # Check Tweet timestamp.
-    # Timestamps on the entities must match the tweet exactly to the second.
-    if actual_tweet.timestamp != entity.datetime:
-        bt.logging.info(
-            f"Tweet and Entity timestamps do not match to the second: {entity.datetime} != {actual_tweet.timestamp}."
-        )
-        return ValidationResult(
-            is_valid=False,
-            reason="Tweet and Entity timestamps do not match to the second",
-            content_size_bytes_validated=entity.content_size_bytes,
-        )
-
     # Timestamps on the contents within the entities must be obfuscated to the minute.
     actual_tweet_obfuscated_timestamp = utils.obfuscate_datetime_to_minute(
         actual_tweet.timestamp

--- a/scraping/x/utils.py
+++ b/scraping/x/utils.py
@@ -73,7 +73,7 @@ def sanitize_scraped_tweet(text: str) -> str:
 
 
 def validate_tweet_content(
-    actual_tweet: XContent, entity: DataEntity, require_obfuscated_content_date: bool
+    actual_tweet: XContent, entity: DataEntity
 ) -> ValidationResult:
     """Validates the tweet is valid by the definition provided by entity."""
     tweet_to_verify = None
@@ -123,59 +123,39 @@ def validate_tweet_content(
         )
 
     # Check Tweet timestamp.
-    # Previously we only validated to the minute granularity to support data scraped by older apify actors.
-    # When obfuscating the date in the content we need to go to the second since the obfuscated date is to the minute.
-
-    # We only go to minute granularity since that is all previous scrapers offered.
-    actual_tweet.timestamp = (
-        actual_tweet.timestamp.replace(microsecond=0)
-        if require_obfuscated_content_date
-        else actual_tweet.timestamp.replace(second=0, microsecond=0)
-    )
-    tweet_to_verify.timestamp = (
-        tweet_to_verify.timestamp.replace(microsecond=0)
-        if require_obfuscated_content_date
-        else tweet_to_verify.timestamp.replace(second=0, microsecond=0)
-    )
-    entity.datetime = (
-        entity.datetime.replace(microsecond=0)
-        if require_obfuscated_content_date
-        else entity.datetime.replace(second=0, microsecond=0)
-    )
-
-    # If checking an data entity with obfuscated content we compare to the entity directly instead.
-    if require_obfuscated_content_date:
-        actual_tweet_obfuscated_timestamp = utils.obfuscate_datetime_to_minute(
-            actual_tweet.timestamp
+    # Timestamps on the entities must match the tweet exactly to the second.
+    if actual_tweet.timestamp != entity.datetime:
+        bt.logging.info(
+            f"Tweet and Entity timestamps do not match to the second: {entity.datetime} != {actual_tweet.timestamp}."
         )
-        if tweet_to_verify.timestamp != actual_tweet_obfuscated_timestamp:
-            # Check if this is specifically because the entity was not obfuscated.
-            if tweet_to_verify.timestamp == actual_tweet.timestamp:
-                bt.logging.info(
-                    f"Provided tweet content datetime was not obfuscated to the minute as required. {tweet_to_verify}"
-                )
-                return ValidationResult(
-                    is_valid=False,
-                    reason="Provided tweet content datetime was not obfuscated to the minute as required",
-                    content_size_bytes_validated=entity.content_size_bytes,
-                )
-            else:
-                bt.logging.info(
-                    f"Tweet timestamps do not match to the minute: {tweet_to_verify} != {actual_tweet}."
-                )
-                return ValidationResult(
-                    is_valid=False,
-                    reason="Tweet timestamps do not match to the minute",
-                    content_size_bytes_validated=entity.content_size_bytes,
-                )
-    else:
-        if tweet_to_verify.timestamp != actual_tweet.timestamp:
+        return ValidationResult(
+            is_valid=False,
+            reason="Tweet and Entity timestamps do not match to the second",
+            content_size_bytes_validated=entity.content_size_bytes,
+        )
+
+    # Timestamps on the contents within the entities must be obfuscated to the minute.
+    actual_tweet_obfuscated_timestamp = utils.obfuscate_datetime_to_minute(
+        actual_tweet.timestamp
+    )
+    if tweet_to_verify.timestamp != actual_tweet_obfuscated_timestamp:
+        # Check if this is specifically because the entity was not obfuscated.
+        if tweet_to_verify.timestamp == actual_tweet.timestamp:
+            bt.logging.info(
+                f"Provided tweet content datetime was not obfuscated to the minute as required. {tweet_to_verify.timestamp} != {actual_tweet_obfuscated_timestamp}"
+            )
+            return ValidationResult(
+                is_valid=False,
+                reason="Provided tweet content datetime was not obfuscated to the minute as required",
+                content_size_bytes_validated=entity.content_size_bytes,
+            )
+        else:
             bt.logging.info(
                 f"Tweet timestamps do not match to the minute: {tweet_to_verify} != {actual_tweet}."
             )
             return ValidationResult(
                 is_valid=False,
-                reason="Tweet timestamps do not match",
+                reason="Tweet timestamps do not match to the minute",
                 content_size_bytes_validated=entity.content_size_bytes,
             )
 
@@ -204,10 +184,7 @@ def validate_tweet_content(
     # Wahey! A valid Tweet.
     # One final check. Does the tweet content match the data entity information?
     try:
-        # It does not matter if we obfuscate the content here since we only check non content.
-        tweet_entity = XContent.to_data_entity(
-            content=actual_tweet, obfuscate_content_date=False
-        )
+        tweet_entity = XContent.to_data_entity(content=actual_tweet)
 
         # Extra check that the content size is reasonably close to what we expect.
         # Allow a 10 byte difference to account for timestamp serialization differences.

--- a/tests/scraping/reddit/test_model.py
+++ b/tests/scraping/reddit/test_model.py
@@ -19,9 +19,7 @@ class TestModel(unittest.TestCase):
             dataType=RedditDataType.POST,
             title="Title text",
         )
-        entity = RedditContent.to_data_entity(
-            content=content, obfuscate_content_date=False
-        )
+        entity = RedditContent.to_data_entity(content=content)
 
         self.assertEqual(len(entity.label.value), constants.MAX_LABEL_LENGTH)
         self.assertEqual(entity.label.value, "r/looooooooooooooooooooooooongsu")
@@ -39,44 +37,10 @@ class TestModel(unittest.TestCase):
             dataType=RedditDataType.POST,
             title="Title text",
         )
-        entity = RedditContent.to_data_entity(
-            content=content, obfuscate_content_date=False
-        )
+        entity = RedditContent.to_data_entity(content=content)
 
         self.assertEqual(len(entity.label.value), constants.MAX_LABEL_LENGTH)
         self.assertEqual(entity.label.value, "r/i̇srailleticaretfilistinei̇han")
-
-    def test_to_data_entity_non_obfuscated(self):
-        timestamp = dt.datetime(
-            year=2024,
-            month=1,
-            day=2,
-            hour=3,
-            minute=4,
-            second=5,
-            microsecond=6,
-            tzinfo=dt.timezone.utc,
-        )
-        content = RedditContent(
-            id="postId",
-            url="https://reddit.com/123",
-            username="user1",
-            communityName="r/bitcoin",
-            body="Hello world",
-            createdAt=timestamp,
-            dataType=RedditDataType.POST,
-            title="Title text",
-        )
-
-        # Convert to entity and back to check granularity of the content timestamp.
-        entity = RedditContent.to_data_entity(
-            content=content, obfuscate_content_date=False
-        )
-        content_roundtrip = RedditContent.from_data_entity(entity)
-
-        # Both the entity datetime and the entity content datetime should have full granularity.
-        self.assertEqual(entity.datetime, timestamp)
-        self.assertEqual(content_roundtrip.created_at, timestamp)
 
     def test_to_data_entity_obfuscated(self):
         timestamp = dt.datetime(
@@ -101,9 +65,7 @@ class TestModel(unittest.TestCase):
         )
 
         # Convert to entity and back to check granularity of the content timestamp.
-        entity = RedditContent.to_data_entity(
-            content=content, obfuscate_content_date=True
-        )
+        entity = RedditContent.to_data_entity(content=content)
         content_roundtrip = RedditContent.from_data_entity(entity)
 
         # The entity datetime should have full granularity but the roundtripped content should not.
@@ -136,9 +98,7 @@ class TestModel(unittest.TestCase):
         )
 
         # Convert to entity and back to check granularity of the content timestamp.
-        entity = RedditContent.to_data_entity(
-            content=content, obfuscate_content_date=True
-        )
+        entity = RedditContent.to_data_entity(content=content)
 
         self.assertEqual(
             entity.content,

--- a/tests/scraping/reddit/test_utils.py
+++ b/tests/scraping/reddit/test_utils.py
@@ -55,9 +55,42 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_reddit_content(
-            actual_content, entity_to_validate, True
+            actual_content, entity_to_validate
         )
         self.assertTrue(validation_result.is_valid)
+
+    def test_validate_reddit_content_obfuscated_date_required(self):
+        """Performs a validation on a RedditContent that hasn't obfuscated the date and verifies
+        the validation fails."""
+        actual_content = RedditContent(
+            id="t1_kc3w8lk",
+            url="https://www.reddit.com/r/bittensor_/comments/18bf67l/how_do_you_add_tao_to_metamask/kc3w8lk/",
+            username="KOOLBREEZE144",
+            communityName="r/bittensor_",
+            body="Thanks for responding. Do you recommend a wallet or YT video on setting this up? What do you use?",
+            createdAt=dt.datetime(2023, 12, 5, 16, 35, 16, tzinfo=dt.timezone.utc),
+            dataType=RedditDataType.COMMENT,
+            title=None,
+            parentId="t1_kc3vd3n",
+        )
+
+        entity_to_validate = DataEntity(
+            uri="https://www.reddit.com/r/bittensor_/comments/18bf67l/how_do_you_add_tao_to_metamask/kc3w8lk/",
+            datetime=dt.datetime(2023, 12, 5, 16, 35, 16, tzinfo=dt.timezone.utc),
+            source=DataSource.REDDIT,
+            label=DataLabel(value="r/bittensor_"),
+            content=b'{"id": "t1_kc3w8lk", "url": "https://www.reddit.com/r/bittensor_/comments/18bf67l/how_do_you_add_tao_to_metamask/kc3w8lk/", "username": "KOOLBREEZE144", "communityName": "r/bittensor_", "body": "Thanks for responding. Do you recommend a wallet or YT video on setting this up? What do you use?", "createdAt": "2023-12-05T16:35:16+00:00", "dataType": "comment", "parentId": "t1_kc3vd3n"}',
+            content_size_bytes=392,
+        )
+
+        validation_result = utils.validate_reddit_content(
+            actual_content, entity_to_validate
+        )
+        self.assertFalse(validation_result.is_valid)
+        self.assertIn(
+            "was not obfuscated",
+            validation_result.reason,
+        )
 
     def test_validate_reddit_content_extra_fields_prohibited(self):
         """Verifies the RedditContent doesn't allow extra fields"""
@@ -83,9 +116,10 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_reddit_content(
-            actual_content, entity_to_validate, True
+            actual_content, entity_to_validate
         )
         self.assertFalse(validation_result.is_valid)
+        self.assertIn("Failed to decode data entity", validation_result.reason)
 
     def test_validate_reddit_content_extra_bytes_below_limit(self):
         """Verifies the RedditContent allows a small amount of additional bytes on the content."""

--- a/tests/scraping/reddit/test_utils.py
+++ b/tests/scraping/reddit/test_utils.py
@@ -146,7 +146,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_reddit_content(
-            actual_content, entity_to_validate, True
+            actual_content, entity_to_validate
         )
         self.assertTrue(validation_result.is_valid)
 
@@ -175,7 +175,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_reddit_content(
-            actual_content, entity_to_validate, True
+            actual_content, entity_to_validate
         )
         self.assertFalse(validation_result.is_valid)
 

--- a/tests/scraping/x/test_model.py
+++ b/tests/scraping/x/test_model.py
@@ -64,7 +64,7 @@ class TestModel(unittest.TestCase):
             timestamp=timestamp,
             tweet_hashtags=["#loooooooooooooooooooooooonghashtag", "$TAO"],
         )
-        entity = XContent.to_data_entity(content=content, obfuscate_content_date=False)
+        entity = XContent.to_data_entity(content=content)
 
         self.assertEqual(len(entity.label.value), constants.MAX_LABEL_LENGTH)
         self.assertEqual(entity.label.value, "#loooooooooooooooooooooooonghash")
@@ -79,37 +79,10 @@ class TestModel(unittest.TestCase):
             timestamp=timestamp,
             tweet_hashtags=["#İsrailleTicaretFilistineİhanet", "$TAO"],
         )
-        entity = XContent.to_data_entity(content=content, obfuscate_content_date=False)
+        entity = XContent.to_data_entity(content=content)
 
         self.assertEqual(len(entity.label.value), constants.MAX_LABEL_LENGTH)
         self.assertEqual(entity.label.value, "#i̇srailleticaretfilistinei̇hane")
-
-    def test_to_data_entity_non_obfuscated(self):
-        timestamp = dt.datetime(
-            year=2024,
-            month=1,
-            day=2,
-            hour=3,
-            minute=4,
-            second=5,
-            microsecond=6,
-            tzinfo=dt.timezone.utc,
-        )
-        content = XContent(
-            username="user1",
-            text="Hello world",
-            url="https://twitter.com/123",
-            timestamp=timestamp,
-            tweet_hashtags=["#bittensor", "$TAO"],
-        )
-
-        # Convert to entity and back to check granularity of the content timestamp.
-        entity = XContent.to_data_entity(content=content, obfuscate_content_date=False)
-        content_roundtrip = XContent.from_data_entity(entity)
-
-        # Both the entity datetime and the entity content datetime should have full granularity.
-        self.assertEqual(entity.datetime, timestamp)
-        self.assertEqual(content_roundtrip.timestamp, timestamp)
 
     def test_to_data_entity_obfuscated(self):
         timestamp = dt.datetime(
@@ -131,7 +104,7 @@ class TestModel(unittest.TestCase):
         )
 
         # Convert to entity and back to check granularity of the content timestamp.
-        entity = XContent.to_data_entity(content=content, obfuscate_content_date=True)
+        entity = XContent.to_data_entity(content=content)
         content_roundtrip = XContent.from_data_entity(entity)
 
         # The entity datetime should have full granularity but the roundtripped content should not.
@@ -161,7 +134,7 @@ class TestModel(unittest.TestCase):
         )
 
         # Convert to entity and back to check granularity of the content timestamp.
-        entity = XContent.to_data_entity(content=content, obfuscate_content_date=True)
+        entity = XContent.to_data_entity(content=content)
 
         # The content should not contain the model_config field.
         self.assertEqual(

--- a/tests/scraping/x/test_utils.py
+++ b/tests/scraping/x/test_utils.py
@@ -175,7 +175,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_tweet_content(
-            actual_tweet, entity_to_validate, True
+            actual_tweet, entity_to_validate
         )
         self.assertTrue(validation_result.is_valid)
 
@@ -200,7 +200,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_tweet_content(
-            actual_tweet, entity_to_validate, True
+            actual_tweet, entity_to_validate
         )
         self.assertFalse(validation_result.is_valid)
 
@@ -225,7 +225,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_tweet_content(
-            actual_tweet, entity_to_validate, True
+            actual_tweet, entity_to_validate
         )
         self.assertFalse(validation_result.is_valid)
 

--- a/tests/scraping/x/test_utils.py
+++ b/tests/scraping/x/test_utils.py
@@ -77,7 +77,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_tweet_content(
-            actual_tweet, entity_to_validate, True
+            actual_tweet, entity_to_validate
         )
         self.assertTrue(validation_result.is_valid)
 
@@ -101,7 +101,7 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_tweet_content(
-            actual_tweet, entity_to_validate, True
+            actual_tweet, entity_to_validate
         )
         self.assertFalse(validation_result.is_valid)
 
@@ -125,9 +125,34 @@ class TestUtils(unittest.TestCase):
         )
 
         validation_result = utils.validate_tweet_content(
-            actual_tweet, entity_to_validate, True
+            actual_tweet, entity_to_validate
         )
         self.assertFalse(validation_result.is_valid)
+
+    def test_validate_tweet_content_requires_obfuscated_date(self):
+        """Validates a tweet validation requires an obfuscated date."""
+        actual_tweet = XContent(
+            username="@bittensor_alert",
+            text="🚨 #Bittensor Alert: 500 $TAO ($122,655) deposited into #MEXC",
+            url="https://twitter.com/bittensor_alert/status/1748585332935622672",
+            timestamp=dt.datetime(2024, 1, 20, 5, 56, 45, tzinfo=dt.timezone.utc),
+            tweet_hashtags=["#Bittensor", "#TAO", "#MEXC"],
+        )
+
+        entity_to_validate = DataEntity(
+            uri="https://twitter.com/bittensor_alert/status/1748585332935622672",
+            datetime=dt.datetime(2024, 1, 20, 5, 56, 45, tzinfo=dt.timezone.utc),
+            source=DataSource.X,
+            label=DataLabel(value="#Bittensor"),
+            content='{"username":"@bittensor_alert","text":"🚨 #Bittensor Alert: 500 $TAO ($122,655) deposited into #MEXC","url":"https://twitter.com/bittensor_alert/status/1748585332935622672","timestamp":"2024-01-20T5:56:45Z","tweet_hashtags":["#Bittensor", "#TAO", "#MEXC"],"model_config":{"extra": "ignore"}}',
+            content_size_bytes=291,
+        )
+
+        validation_result = utils.validate_tweet_content(
+            actual_tweet, entity_to_validate
+        )
+        self.assertFalse(validation_result.is_valid)
+        self.assertIn("was not obfuscated", validation_result.reason)
 
     def test_validate_tweet_content_extra_bytes_below_limit(self):
         """Validates a tweet with extra bytes below the limit passes validation."""


### PR DESCRIPTION
We're now more than 30 days since we required all content to have an obfuscated datetime in the serialized content. This change cleans up the old code and always enforces the obfuscation requirement